### PR TITLE
Ensure consistent form submission results

### DIFF
--- a/components/forms/advertising-form.tsx
+++ b/components/forms/advertising-form.tsx
@@ -26,6 +26,7 @@ import { advertisingFormSchema, type AdvertisingFormData } from "@/lib/validatio
 import { submitAdvertisingForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { useFormAnalytics } from "@/hooks/use-form-analytics"
+import { messages } from "@/lib/i18n"
 import { Megaphone, Truck, Monitor, Target, Calendar, Shield, CheckCircle, AlertCircle } from "lucide-react"
 
 interface AdvertisingFormProps {
@@ -195,6 +196,7 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
 
   const onSubmit = async (data: AdvertisingFormData) => {
     setIsSubmitting(true)
+    setSubmitResult(null)
     analytics.trackSubmissionAttempt()
 
     try {
@@ -209,13 +211,18 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
 
       formData.append("sessionId", analyticsClient.getSessionId())
       const result = await submitAdvertisingForm(formData)
-      setSubmitResult(result)
+      const message =
+        result.message ??
+        (result.success
+          ? messages.form.success[language]
+          : messages.form.serverError[language])
+      setSubmitResult({ success: result.success, message })
 
       if (result.success) {
         analytics.trackSubmissionSuccess()
         reset()
       } else {
-        analytics.trackSubmissionError(result.message)
+        analytics.trackSubmissionError(message)
       }
     } catch (error) {
       const errorMessage =

--- a/components/forms/coworking-form.tsx
+++ b/components/forms/coworking-form.tsx
@@ -26,6 +26,7 @@ import { coworkingFormSchema, type CoworkingFormData } from "@/lib/validation-sc
 import { submitCoworkingForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { useFormAnalytics } from "@/hooks/use-form-analytics"
+import { messages } from "@/lib/i18n"
 import { Users, Coffee, Calendar, Shield, CheckCircle, AlertCircle, MapPin } from "lucide-react"
 
 interface CoworkingFormProps {
@@ -165,6 +166,7 @@ export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
 
   const onSubmit = async (data: CoworkingFormData) => {
     setIsSubmitting(true)
+    setSubmitResult(null)
     analytics.trackSubmissionAttempt()
 
     try {
@@ -179,13 +181,18 @@ export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
 
       formData.append("sessionId", analyticsClient.getSessionId())
       const result = await submitCoworkingForm(formData)
-      setSubmitResult(result)
+      const message =
+        result.message ??
+        (result.success
+          ? messages.form.success[language]
+          : messages.form.serverError[language])
+      setSubmitResult({ success: result.success, message })
 
       if (result.success) {
         analytics.trackSubmissionSuccess()
         reset()
       } else {
-        analytics.trackSubmissionError(result.message)
+        analytics.trackSubmissionError(message)
       }
     } catch (error) {
       const errorMessage =

--- a/components/forms/meeting-room-form.tsx
+++ b/components/forms/meeting-room-form.tsx
@@ -26,6 +26,7 @@ import { meetingRoomFormSchema, type MeetingRoomFormData } from "@/lib/validatio
 import { submitMeetingRoomForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { useFormAnalytics } from "@/hooks/use-form-analytics"
+import { messages } from "@/lib/i18n"
 import { Calendar, Clock, Users, Coffee, Shield, CheckCircle, AlertCircle } from "lucide-react"
 
 interface MeetingRoomFormProps {
@@ -209,6 +210,7 @@ export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProp
 
   const onSubmit = async (data: MeetingRoomFormData) => {
     setIsSubmitting(true)
+    setSubmitResult(null)
     analytics.trackSubmissionAttempt()
 
     try {
@@ -223,13 +225,18 @@ export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProp
 
       formData.append("sessionId", analyticsClient.getSessionId())
       const result = await submitMeetingRoomForm(formData)
-      setSubmitResult(result)
+      const message =
+        result.message ??
+        (result.success
+          ? messages.form.success[language]
+          : messages.form.serverError[language])
+      setSubmitResult({ success: result.success, message })
 
       if (result.success) {
         analytics.trackSubmissionSuccess()
         reset()
       } else {
-        analytics.trackSubmissionError(result.message)
+        analytics.trackSubmissionError(message)
       }
     } catch (error) {
       const errorMessage =

--- a/components/forms/special-deals-form.tsx
+++ b/components/forms/special-deals-form.tsx
@@ -27,6 +27,7 @@ import { specialDealsFormSchema, type SpecialDealsFormData } from "@/lib/validat
 import { submitSpecialDealsForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { useFormAnalytics } from "@/hooks/use-form-analytics"
+import { messages } from "@/lib/i18n"
 import { Gift, Percent, Star, Shield, CheckCircle, AlertCircle } from "lucide-react"
 
 interface SpecialDealsFormProps {
@@ -215,6 +216,7 @@ export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormPr
 
   const onSubmit = async (data: SpecialDealsFormData) => {
     setIsSubmitting(true)
+    setSubmitResult(null)
     analytics.trackSubmissionAttempt()
 
     try {
@@ -229,13 +231,18 @@ export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormPr
 
       formData.append("sessionId", analyticsClient.getSessionId())
       const result = await submitSpecialDealsForm(formData)
-      setSubmitResult(result)
+      const message =
+        result.message ??
+        (result.success
+          ? messages.form.success[language]
+          : messages.form.serverError[language])
+      setSubmitResult({ success: result.success, message })
 
       if (result.success) {
         analytics.trackSubmissionSuccess()
         reset()
       } else {
-        analytics.trackSubmissionError(result.message)
+        analytics.trackSubmissionError(message)
       }
     } catch (error) {
       const errorMessage =

--- a/components/forms/virtual-office-form.tsx
+++ b/components/forms/virtual-office-form.tsx
@@ -194,6 +194,7 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
 
   const onSubmit = async (data: VirtualOfficeFormData) => {
     setIsSubmitting(true)
+    setSubmitResult(null)
     analytics.trackSubmissionAttempt()
 
     try {
@@ -208,13 +209,18 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
 
       formData.append("sessionId", analyticsClient.getSessionId())
       const result = await submitVirtualOfficeForm(formData)
-      setSubmitResult(result)
+      const message =
+        result.message ??
+        (result.success
+          ? messages.form.success[language]
+          : messages.form.serverError[language])
+      setSubmitResult({ success: result.success, message })
 
       if (result.success) {
         analytics.trackSubmissionSuccess()
         reset()
       } else {
-        analytics.trackSubmissionError(result.message)
+        analytics.trackSubmissionError(message)
       }
     } catch (error) {
       let errorMessage = messages.form.serverError[language]


### PR DESCRIPTION
## Summary
- Reset submit result before each form submission attempt
- Add localized fallback messages when submission result lacks message
- Pass message to analytics error tracking to avoid undefined entries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4d5c2a3fc832990fc0ba0f6396e9b