### PR TITLE
Remove submit result markup and test toasts

### DIFF
--- a/__tests__/components/forms/coworking-form.test.tsx
+++ b/__tests__/components/forms/coworking-form.test.tsx
@@ -3,6 +3,7 @@ import { CoworkingForm } from "@/components/forms"
 import { submitCoworkingForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { messages } from "@/lib/i18n"
+import { toast } from "@/components/ui"
 import { vi } from "vitest"
 
 const resetMock = vi.fn()
@@ -48,28 +49,23 @@ describe("CoworkingForm", () => {
     vi.clearAllMocks()
   })
 
-  it("clears submitResult before a new attempt", async () => {
+  it("does not reuse toast between submissions", async () => {
     mockSubmit.mockResolvedValueOnce({ success: true, message: "OK" })
     render(<CoworkingForm />)
     const form = screen.getByTestId("contact-form-coworking")
     await fireEvent.submit(form)
-    await screen.findByTestId("submit-result")
-    expect(screen.getByTestId("submit-result")).toHaveTextContent("OK")
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("OK"))
 
     mockSubmit.mockImplementation(() => new Promise(() => {}))
     await fireEvent.submit(form)
-    await waitFor(() => {
-      expect(screen.queryByTestId("submit-result")).not.toBeInTheDocument()
-    })
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
   it("shows success message and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<CoworkingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-coworking"))
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent("Success"),
-    )
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Success"))
     expect(resetMock).toHaveBeenCalled()
   })
 
@@ -78,9 +74,7 @@ describe("CoworkingForm", () => {
     render(<CoworkingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-coworking"))
     const fallback = messages.form.serverError.pl
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent(fallback),
-    )
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(fallback))
     expect(analyticsClient.trackSubmissionError).toHaveBeenCalledWith(
       "coworking",
       fallback,

--- a/__tests__/components/forms/meeting-room-form.test.tsx
+++ b/__tests__/components/forms/meeting-room-form.test.tsx
@@ -3,6 +3,7 @@ import { MeetingRoomForm } from "@/components/forms"
 import { submitMeetingRoomForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { messages } from "@/lib/i18n"
+import { toast } from "@/components/ui"
 import { vi } from "vitest"
 
 const resetMock = vi.fn()
@@ -48,28 +49,23 @@ describe("MeetingRoomForm", () => {
     vi.clearAllMocks()
   })
 
-  it("clears submitResult before a new attempt", async () => {
+  it("does not reuse toast between submissions", async () => {
     mockSubmit.mockResolvedValueOnce({ success: true, message: "OK" })
     render(<MeetingRoomForm />)
     const form = screen.getByTestId("contact-form-meeting-room")
     await fireEvent.submit(form)
-    await screen.findByTestId("submit-result")
-    expect(screen.getByTestId("submit-result")).toHaveTextContent("OK")
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("OK"))
 
     mockSubmit.mockImplementation(() => new Promise(() => {}))
     await fireEvent.submit(form)
-    await waitFor(() => {
-      expect(screen.queryByTestId("submit-result")).not.toBeInTheDocument()
-    })
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
   it("shows success message and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<MeetingRoomForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-meeting-room"))
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent("Success"),
-    )
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Success"))
     expect(resetMock).toHaveBeenCalled()
   })
 
@@ -78,9 +74,7 @@ describe("MeetingRoomForm", () => {
     render(<MeetingRoomForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-meeting-room"))
     const fallback = messages.form.serverError.pl
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent(fallback),
-    )
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(fallback))
     expect(analyticsClient.trackSubmissionError).toHaveBeenCalledWith(
       "meeting-room",
       fallback,

--- a/__tests__/components/forms/special-deals-form.test.tsx
+++ b/__tests__/components/forms/special-deals-form.test.tsx
@@ -3,6 +3,7 @@ import { SpecialDealsForm } from "@/components/forms"
 import { submitSpecialDealsForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { messages } from "@/lib/i18n"
+import { toast } from "@/components/ui"
 import { vi } from "vitest"
 
 const resetMock = vi.fn()
@@ -48,28 +49,23 @@ describe("SpecialDealsForm", () => {
     vi.clearAllMocks()
   })
 
-  it("clears submitResult before a new attempt", async () => {
+  it("does not reuse toast between submissions", async () => {
     mockSubmit.mockResolvedValueOnce({ success: true, message: "OK" })
     render(<SpecialDealsForm />)
     const form = screen.getByTestId("contact-form-special-deals")
     await fireEvent.submit(form)
-    await screen.findByTestId("submit-result")
-    expect(screen.getByTestId("submit-result")).toHaveTextContent("OK")
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("OK"))
 
     mockSubmit.mockImplementation(() => new Promise(() => {}))
     await fireEvent.submit(form)
-    await waitFor(() => {
-      expect(screen.queryByTestId("submit-result")).not.toBeInTheDocument()
-    })
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
   it("shows success message and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<SpecialDealsForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-special-deals"))
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent("Success"),
-    )
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Success"))
     expect(resetMock).toHaveBeenCalled()
   })
 
@@ -78,9 +74,7 @@ describe("SpecialDealsForm", () => {
     render(<SpecialDealsForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-special-deals"))
     const fallback = messages.form.serverError.pl
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent(fallback),
-    )
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(fallback))
     expect(analyticsClient.trackSubmissionError).toHaveBeenCalledWith(
       "special-deals",
       fallback,

--- a/__tests__/components/forms/virtual-office-form.test.tsx
+++ b/__tests__/components/forms/virtual-office-form.test.tsx
@@ -3,6 +3,7 @@ import { VirtualOfficeForm } from "@/components/forms"
 import { submitVirtualOfficeForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { messages } from "@/lib/i18n"
+import { toast } from "@/components/ui"
 import { vi } from "vitest"
 
 const resetMock = vi.fn()
@@ -48,28 +49,23 @@ describe("VirtualOfficeForm", () => {
     vi.clearAllMocks()
   })
 
-  it("clears submitResult before a new attempt", async () => {
+  it("does not reuse toast between submissions", async () => {
     mockSubmit.mockResolvedValueOnce({ success: true, message: "OK" })
     render(<VirtualOfficeForm />)
     const form = screen.getByTestId("contact-form-virtual-office")
     await fireEvent.submit(form)
-    await screen.findByTestId("submit-result")
-    expect(screen.getByTestId("submit-result")).toHaveTextContent("OK")
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("OK"))
 
     mockSubmit.mockImplementation(() => new Promise(() => {}))
     await fireEvent.submit(form)
-    await waitFor(() => {
-      expect(screen.queryByTestId("submit-result")).not.toBeInTheDocument()
-    })
+    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
   it("shows success message and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<VirtualOfficeForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-virtual-office"))
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent("Success"),
-    )
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Success"))
     expect(resetMock).toHaveBeenCalled()
   })
 
@@ -78,9 +74,7 @@ describe("VirtualOfficeForm", () => {
     render(<VirtualOfficeForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-virtual-office"))
     const fallback = messages.form.serverError.pl
-    await waitFor(() =>
-      expect(screen.getByTestId("submit-result")).toHaveTextContent(fallback),
-    )
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(fallback))
     expect(analyticsClient.trackSubmissionError).toHaveBeenCalledWith(
       "virtual-office",
       fallback,

--- a/components/forms/advertising-form.tsx
+++ b/components/forms/advertising-form.tsx
@@ -548,9 +548,6 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
               {isSubmitting ? t.submitting : t.submit}
             </Button>
           </form>
-          {submitResult && (
-            <p data-testid="submit-result">{submitResult.message}</p>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/components/forms/coworking-form.tsx
+++ b/components/forms/coworking-form.tsx
@@ -514,9 +514,6 @@ export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
               {isSubmitting ? t.submitting : t.submit}
             </Button>
           </form>
-          {submitResult && (
-            <p data-testid="submit-result">{submitResult.message}</p>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/components/forms/meeting-room-form.tsx
+++ b/components/forms/meeting-room-form.tsx
@@ -622,9 +622,6 @@ export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProp
               {isSubmitting ? t.submitting : t.submit}
             </Button>
           </form>
-          {submitResult && (
-            <p data-testid="submit-result">{submitResult.message}</p>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/components/forms/special-deals-form.tsx
+++ b/components/forms/special-deals-form.tsx
@@ -564,9 +564,6 @@ export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormPr
               {isSubmitting ? t.submitting : t.submit}
             </Button>
           </form>
-          {submitResult && (
-            <p data-testid="submit-result">{submitResult.message}</p>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/components/forms/virtual-office-form.tsx
+++ b/components/forms/virtual-office-form.tsx
@@ -621,9 +621,6 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
               {isSubmitting ? t.submitting : t.submit}
             </Button>
           </form>
-          {submitResult && (
-            <p data-testid="submit-result">{submitResult.message}</p>
-          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- remove `submitResult` DOM output from form components
- update form unit tests to verify toast notifications instead of DOM text

## Testing
- `npm test -- --run __tests__/components/forms/*.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a57fce6ca0832984fac94a9e4edaf0