### PR TITLE
feat: add global toaster

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google"
 import { cookies } from "next/headers"
 import { LanguageProvider } from "@/components/language-provider"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { Toaster } from "@/components/ui/sonner"
 import "./globals.css"
 
 const inter = Inter({ subsets: ["latin"] })
@@ -115,6 +116,7 @@ export default function RootLayout({
         {/* End Matomo Code */}
       </head>
       <body className={inter.className}>
+        <Toaster />
         <LanguageProvider initialLanguage={currentLanguage}>
           <ErrorBoundary fallback={<p>Something went wrong</p>}>
             {children}


### PR DESCRIPTION
## Summary
- show toast notifications globally by adding `Toaster` provider in root layout

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a58bd86a0c832999fa3800dc4b51cd