### PR TITLE
refactor: remove submit result state from forms

### DIFF
--- a/__tests__/components/forms/advertising-form.test.tsx
+++ b/__tests__/components/forms/advertising-form.test.tsx
@@ -61,7 +61,7 @@ describe("AdvertisingForm", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
-  it("shows success message and resets form", async () => {
+  it("shows success toast and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<AdvertisingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-advertising"))
@@ -69,7 +69,7 @@ describe("AdvertisingForm", () => {
     expect(resetMock).toHaveBeenCalled()
   })
 
-  it("uses fallback message and tracks errors", async () => {
+  it("uses fallback toast message and tracks errors", async () => {
     mockSubmit.mockResolvedValue({ success: false })
     render(<AdvertisingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-advertising"))

--- a/__tests__/components/forms/coworking-form.test.tsx
+++ b/__tests__/components/forms/coworking-form.test.tsx
@@ -61,7 +61,7 @@ describe("CoworkingForm", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
-  it("shows success message and resets form", async () => {
+  it("shows success toast and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<CoworkingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-coworking"))
@@ -69,7 +69,7 @@ describe("CoworkingForm", () => {
     expect(resetMock).toHaveBeenCalled()
   })
 
-  it("uses fallback message and tracks errors", async () => {
+  it("uses fallback toast message and tracks errors", async () => {
     mockSubmit.mockResolvedValue({ success: false })
     render(<CoworkingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-coworking"))

--- a/__tests__/components/forms/meeting-room-form.test.tsx
+++ b/__tests__/components/forms/meeting-room-form.test.tsx
@@ -61,7 +61,7 @@ describe("MeetingRoomForm", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
-  it("shows success message and resets form", async () => {
+  it("shows success toast and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<MeetingRoomForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-meeting-room"))
@@ -69,7 +69,7 @@ describe("MeetingRoomForm", () => {
     expect(resetMock).toHaveBeenCalled()
   })
 
-  it("uses fallback message and tracks errors", async () => {
+  it("uses fallback toast message and tracks errors", async () => {
     mockSubmit.mockResolvedValue({ success: false })
     render(<MeetingRoomForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-meeting-room"))

--- a/__tests__/components/forms/special-deals-form.test.tsx
+++ b/__tests__/components/forms/special-deals-form.test.tsx
@@ -61,7 +61,7 @@ describe("SpecialDealsForm", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
-  it("shows success message and resets form", async () => {
+  it("shows success toast and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<SpecialDealsForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-special-deals"))
@@ -69,7 +69,7 @@ describe("SpecialDealsForm", () => {
     expect(resetMock).toHaveBeenCalled()
   })
 
-  it("uses fallback message and tracks errors", async () => {
+  it("uses fallback toast message and tracks errors", async () => {
     mockSubmit.mockResolvedValue({ success: false })
     render(<SpecialDealsForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-special-deals"))

--- a/__tests__/components/forms/virtual-office-form.test.tsx
+++ b/__tests__/components/forms/virtual-office-form.test.tsx
@@ -61,7 +61,7 @@ describe("VirtualOfficeForm", () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
   })
 
-  it("shows success message and resets form", async () => {
+  it("shows success toast and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<VirtualOfficeForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-virtual-office"))
@@ -69,7 +69,7 @@ describe("VirtualOfficeForm", () => {
     expect(resetMock).toHaveBeenCalled()
   })
 
-  it("uses fallback message and tracks errors", async () => {
+  it("uses fallback toast message and tracks errors", async () => {
     mockSubmit.mockResolvedValue({ success: false })
     render(<VirtualOfficeForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-virtual-office"))

--- a/components/forms/advertising-form.tsx
+++ b/components/forms/advertising-form.tsx
@@ -34,7 +34,6 @@ interface AdvertisingFormProps {
 
 export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitResult, setSubmitResult] = useState<{ success: boolean; message: string } | null>(null)
 
   const analytics = useFormAnalytics({
     formType: "advertising",
@@ -194,7 +193,6 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
   const t = content[language]
 
   const onSubmit = async (data: AdvertisingFormData) => {
-    setSubmitResult(null)
     setIsSubmitting(true)
     analytics.trackSubmissionAttempt()
 
@@ -218,19 +216,16 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
       if (result.success) {
         analytics.trackSubmissionSuccess()
         toast.success(message)
-        setSubmitResult({ success: true, message })
         reset()
       } else {
         analytics.trackSubmissionError(message)
         toast.error(message)
-        setSubmitResult({ success: false, message })
       }
     } catch (error) {
       const errorMessage =
         language === "en" ? "An unexpected error occurred" : "Wystąpił nieoczekiwany błąd"
       analytics.trackSubmissionError(errorMessage)
       toast.error(errorMessage)
-      setSubmitResult({ success: false, message: errorMessage })
     } finally {
       setIsSubmitting(false)
     }

--- a/components/forms/coworking-form.tsx
+++ b/components/forms/coworking-form.tsx
@@ -34,7 +34,6 @@ interface CoworkingFormProps {
 
 export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitResult, setSubmitResult] = useState<{ success: boolean; message: string } | null>(null)
 
   const analytics = useFormAnalytics({
     formType: "coworking",
@@ -164,7 +163,6 @@ export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
   const t = content[language]
 
   const onSubmit = async (data: CoworkingFormData) => {
-    setSubmitResult(null)
     setIsSubmitting(true)
     analytics.trackSubmissionAttempt()
 
@@ -188,19 +186,16 @@ export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
       if (result.success) {
         analytics.trackSubmissionSuccess()
         toast.success(message)
-        setSubmitResult({ success: true, message })
         reset()
       } else {
         analytics.trackSubmissionError(message)
         toast.error(message)
-        setSubmitResult({ success: false, message })
       }
     } catch (error) {
       const errorMessage =
         language === "en" ? "An unexpected error occurred" : "Wystąpił nieoczekiwany błąd"
       analytics.trackSubmissionError(errorMessage)
       toast.error(errorMessage)
-      setSubmitResult({ success: false, message: errorMessage })
     } finally {
       setIsSubmitting(false)
     }

--- a/components/forms/meeting-room-form.tsx
+++ b/components/forms/meeting-room-form.tsx
@@ -34,7 +34,6 @@ interface MeetingRoomFormProps {
 
 export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitResult, setSubmitResult] = useState<{ success: boolean; message: string } | null>(null)
 
   const analytics = useFormAnalytics({
     formType: "meeting-room",
@@ -208,7 +207,6 @@ export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProp
   const t = content[language]
 
   const onSubmit = async (data: MeetingRoomFormData) => {
-    setSubmitResult(null)
     setIsSubmitting(true)
     analytics.trackSubmissionAttempt()
 
@@ -232,19 +230,16 @@ export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProp
       if (result.success) {
         analytics.trackSubmissionSuccess()
         toast.success(message)
-        setSubmitResult({ success: true, message })
         reset()
       } else {
         analytics.trackSubmissionError(message)
         toast.error(message)
-        setSubmitResult({ success: false, message })
       }
     } catch (error) {
       const errorMessage =
         language === "en" ? "An unexpected error occurred" : "Wystąpił nieoczekiwany błąd"
       analytics.trackSubmissionError(errorMessage)
       toast.error(errorMessage)
-      setSubmitResult({ success: false, message: errorMessage })
     } finally {
       setIsSubmitting(false)
     }

--- a/components/forms/special-deals-form.tsx
+++ b/components/forms/special-deals-form.tsx
@@ -35,7 +35,6 @@ interface SpecialDealsFormProps {
 
 export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitResult, setSubmitResult] = useState<{ success: boolean; message: string } | null>(null)
 
   const analytics = useFormAnalytics({
     formType: "special-deals",
@@ -214,7 +213,6 @@ export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormPr
   const t = content[language]
 
   const onSubmit = async (data: SpecialDealsFormData) => {
-    setSubmitResult(null)
     setIsSubmitting(true)
     analytics.trackSubmissionAttempt()
 
@@ -238,19 +236,16 @@ export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormPr
       if (result.success) {
         analytics.trackSubmissionSuccess()
         toast.success(message)
-        setSubmitResult({ success: true, message })
         reset()
       } else {
         analytics.trackSubmissionError(message)
         toast.error(message)
-        setSubmitResult({ success: false, message })
       }
     } catch (error) {
       const errorMessage =
         language === "en" ? "An unexpected error occurred" : "Wystąpił nieoczekiwany błąd"
       analytics.trackSubmissionError(errorMessage)
       toast.error(errorMessage)
-      setSubmitResult({ success: false, message: errorMessage })
     } finally {
       setIsSubmitting(false)
     }

--- a/components/forms/virtual-office-form.tsx
+++ b/components/forms/virtual-office-form.tsx
@@ -34,7 +34,6 @@ interface VirtualOfficeFormProps {
 
 export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [submitResult, setSubmitResult] = useState<{ success: boolean; message: string } | null>(null)
 
   const analytics = useFormAnalytics({
     formType: "virtual-office",
@@ -192,7 +191,6 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
   const t = content[language]
 
   const onSubmit = async (data: VirtualOfficeFormData) => {
-    setSubmitResult(null)
     setIsSubmitting(true)
     analytics.trackSubmissionAttempt()
 
@@ -216,12 +214,10 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
       if (result.success) {
         analytics.trackSubmissionSuccess()
         toast.success(message)
-        setSubmitResult({ success: true, message })
         reset()
       } else {
         analytics.trackSubmissionError(message)
         toast.error(message)
-        setSubmitResult({ success: false, message })
       }
     } catch (error) {
       let errorMessage = messages.form.serverError[language]
@@ -237,7 +233,6 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
       }
       analytics.trackSubmissionError(errorMessage)
       toast.error(errorMessage)
-      setSubmitResult({ success: false, message: errorMessage })
     } finally {
       setIsSubmitting(false)
     }


### PR DESCRIPTION
## Summary
- remove obsolete `submitResult` state from all form components and rely solely on toast notifications
- clarify form unit test descriptions to highlight toast assertions

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a625c296808329aeda3b89acc0fe9b