### PR TITLE
refactor: use form alert test ids

### DIFF
--- a/e2e/forms.spec.ts
+++ b/e2e/forms.spec.ts
@@ -121,10 +121,9 @@ test.describe("Contact Forms", () => {
       ),
       form.locator('button[type="submit"]').click(),
     ]);
-    const successToast = page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: messages.form.success.pl });
-    await expect(successToast).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByTestId("form-success-alert"),
+    ).toBeVisible({ timeout: 15000 });
 
     await unroute();
   });
@@ -256,10 +255,9 @@ test.describe("Contact Forms", () => {
       ),
       form.locator('button[type="submit"]').click(),
     ]);
-    const successToast = page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: messages.form.success.pl });
-    await expect(successToast).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByTestId("form-success-alert"),
+    ).toBeVisible({ timeout: 15000 });
 
     await unroute();
   });
@@ -313,10 +311,9 @@ test.describe("Contact Forms", () => {
       ),
       form.locator('button[type="submit"]').click(),
     ]);
-    const successToast = page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: messages.form.success.pl });
-    await expect(successToast).toBeVisible({ timeout: 15000 });
+    await expect(
+      page.getByTestId("form-success-alert"),
+    ).toBeVisible({ timeout: 15000 });
 
     await unroute();
   });


### PR DESCRIPTION
## Summary
- refactor tests to rely on `form-success-alert` test id

## Testing
- `npx playwright test e2e/forms.spec.ts -g "should submit (virtual office|coworking|meeting room) form successfully"` *(fails: Playwright could not locate system dependencies and later executions did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2ea5c0cc8329a8320820a076e528