### PR TITLE
Remove toast notifications from forms

### DIFF
--- a/__tests__/components/forms/advertising-form.test.tsx
+++ b/__tests__/components/forms/advertising-form.test.tsx
@@ -3,7 +3,6 @@ import { AdvertisingForm } from "@/components/forms"
 import { submitAdvertisingForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
 import { messages } from "@/lib/i18n"
-import { toast } from "@/components/ui/sonner"
 import { vi } from "vitest"
 
 const resetMock = vi.fn()
@@ -21,10 +20,6 @@ vi.mock("react-hook-form", async (importActual) => {
       reset: resetMock,
     }),
   }
-})
-vi.mock("@/components/ui/sonner", async (importActual) => {
-  const actual = (await importActual()) as any
-  return { ...actual, toast: { success: vi.fn(), error: vi.fn() } }
 })
 vi.mock("@/lib/analytics-client", () => ({
   analyticsClient: {
@@ -49,32 +44,46 @@ describe("AdvertisingForm", () => {
     vi.clearAllMocks()
   })
 
-  it("does not reuse toast between submissions", async () => {
+  it("clears previous alert between submissions", async () => {
     mockSubmit.mockResolvedValueOnce({ success: true, message: "OK" })
     render(<AdvertisingForm />)
     const form = screen.getByTestId("contact-form-advertising")
     await fireEvent.submit(form)
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("OK"))
+    await waitFor(() =>
+      expect(screen.getByTestId("form-success-alert")).toHaveTextContent("OK"),
+    )
 
     mockSubmit.mockImplementation(() => new Promise(() => {}))
     await fireEvent.submit(form)
-    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("form-success-alert"),
+      ).not.toBeInTheDocument(),
+    )
   })
 
-  it("shows success toast and resets form", async () => {
+  it("shows success alert and resets form", async () => {
     mockSubmit.mockResolvedValue({ success: true, message: "Success" })
     render(<AdvertisingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-advertising"))
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith("Success"))
+    await waitFor(() =>
+      expect(screen.getByTestId("form-success-alert")).toHaveTextContent(
+        "Success",
+      ),
+    )
     expect(resetMock).toHaveBeenCalled()
   })
 
-  it("uses fallback toast message and tracks errors", async () => {
+  it("uses fallback alert message and tracks errors", async () => {
     mockSubmit.mockResolvedValue({ success: false })
     render(<AdvertisingForm />)
     await fireEvent.submit(screen.getByTestId("contact-form-advertising"))
     const fallback = messages.form.serverError.pl
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(fallback))
+    await waitFor(() =>
+      expect(screen.getByTestId("form-error-alert")).toHaveTextContent(
+        fallback,
+      ),
+    )
     expect(analyticsClient.trackSubmissionError).toHaveBeenCalledWith(
       "advertising",
       fallback,

--- a/components/forms/advertising-form.tsx
+++ b/components/forms/advertising-form.tsx
@@ -22,7 +22,6 @@ import {
   Alert,
   AlertDescription,
 } from "@/components/ui"
-import { toast } from "@/components/ui/sonner"
 import { advertisingFormSchema, type AdvertisingFormData } from "@/lib/validation-schemas"
 import { submitAdvertisingForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
@@ -223,18 +222,15 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
       setSubmitResult({ success: result.success, message })
       if (result.success) {
         analytics.trackSubmissionSuccess()
-        toast.success(message)
         reset()
       } else {
         analytics.trackSubmissionError(message)
-        toast.error(message)
       }
     } catch (error) {
       const errorMessage =
         language === "en" ? "An unexpected error occurred" : "Wystąpił nieoczekiwany błąd"
       analytics.trackSubmissionError(errorMessage)
       setSubmitResult({ success: false, message: errorMessage })
-      toast.error(errorMessage)
     } finally {
       setIsSubmitting(false)
     }

--- a/components/forms/virtual-office-form.tsx
+++ b/components/forms/virtual-office-form.tsx
@@ -22,7 +22,6 @@ import {
   Alert,
   AlertDescription,
 } from "@/components/ui"
-import { toast } from "@/components/ui/sonner"
 import { virtualOfficeFormSchema, type VirtualOfficeFormData } from "@/lib/validation-schemas"
 import { submitVirtualOfficeForm } from "@/lib/server-actions"
 import { analyticsClient } from "@/lib/analytics-client"
@@ -218,11 +217,9 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
       setSubmitResult({ success: result.success, message })
       if (result.success) {
         analytics.trackSubmissionSuccess()
-        toast.success(message)
         reset()
       } else {
         analytics.trackSubmissionError(message)
-        toast.error(message)
       }
     } catch (error) {
       let errorMessage = messages.form.serverError[language]
@@ -238,7 +235,6 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
       }
       analytics.trackSubmissionError(errorMessage)
       setSubmitResult({ success: false, message: errorMessage })
-      toast.error(errorMessage)
     } finally {
       setIsSubmitting(false)
     }


### PR DESCRIPTION
## Summary
- Drop toast usage from virtual office and advertising forms
- Use alert-based messaging for submission results
- Update tests to expect alerts instead of toasts

## Testing
- `npm test -- --run __tests__/components/forms/virtual-office-form.test.tsx __tests__/components/forms/advertising-form.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab3287f39083298bda03c4fd902db1