### PR TITLE
Replace toast locator with error alert in forms e2e test

### DIFF
--- a/e2e/forms.spec.ts
+++ b/e2e/forms.spec.ts
@@ -365,10 +365,8 @@ test.describe("Contact Forms", () => {
       ),
       form.locator('button[type="submit"]').click(),
     ]);
-    const errorToast = page
-      .locator("[data-sonner-toast]")
-      .filter({ hasText: messages.form.serverError.pl });
-    await expect(errorToast).toBeVisible({ timeout: 15000 });
+    const errorAlert = page.getByTestId("form-error-alert");
+    await expect(errorAlert).toBeVisible({ timeout: 15000 });
 
     await unroute();
   });


### PR DESCRIPTION
## Summary
- reference `form-error-alert` test id instead of toast locator in submission error test

## Testing
- `npx playwright test e2e/forms.spec.ts --grep "should handle form submission errors gracefully"` *(fails: page.waitForResponse timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ab68b7ae7083299285768dfb4f3242