### PR TITLE
Use mock flags to short-circuit form submission

### DIFF
--- a/__tests__/lib/server-actions.test.ts
+++ b/__tests__/lib/server-actions.test.ts
@@ -386,15 +386,37 @@ describe("Server Actions", () => {
     });
   });
 
-  describe("test environment shortcut", () => {
-    it("returns test submission without side effects", async () => {
-      process.env.NODE_ENV = "test";
+  describe("mock environment shortcut", () => {
+    it("returns success message without side effects", async () => {
+      process.env.MOCK_DB = "true";
+      (getCurrentLanguage as any).mockResolvedValue("pl");
       const formData = new FormData();
       const result = await submitVirtualOfficeForm(formData);
-      expect(result).toEqual({ success: true, message: "Test submission" });
+      expect(result).toEqual({
+        success: true,
+        message: messages.form.success.pl,
+      });
       expect(emailClient.sendEmail).not.toHaveBeenCalled();
       expect(db.query).not.toHaveBeenCalled();
       expect(saveFailedEmail).not.toHaveBeenCalled();
+      delete process.env.MOCK_DB;
+    });
+
+    it("returns server error when forced error flag is set", async () => {
+      process.env.MOCK_DB = "true";
+      process.env.FORCED_FORM_ERROR = "true";
+      (getCurrentLanguage as any).mockResolvedValue("en");
+      const formData = new FormData();
+      const result = await submitVirtualOfficeForm(formData);
+      expect(result).toEqual({
+        success: false,
+        message: messages.form.serverError.en,
+      });
+      expect(emailClient.sendEmail).not.toHaveBeenCalled();
+      expect(db.query).not.toHaveBeenCalled();
+      expect(saveFailedEmail).not.toHaveBeenCalled();
+      delete process.env.MOCK_DB;
+      delete process.env.FORCED_FORM_ERROR;
     });
   });
 });

--- a/lib/server-actions.ts
+++ b/lib/server-actions.ts
@@ -80,8 +80,14 @@ async function handleFormSubmission<T>(
   errors?: Record<string, string>;
   status?: number;
 }> {
-  if (process.env.NODE_ENV === "test") {
-    return { success: true, message: "Test submission" };
+  const isTest =
+    process.env.MOCK_DB === "true" || process.env.MOCK_EMAIL === "true";
+  if (isTest) {
+    const lang = await getCurrentLanguage();
+    if (process.env.FORCED_FORM_ERROR === "true") {
+      return { success: false, message: messages.form.serverError[lang] };
+    }
+    return { success: true, message: messages.form.success[lang] };
   }
 
   try {


### PR DESCRIPTION
## Summary
- Short-circuit form submission when MOCK_DB or MOCK_EMAIL is enabled, with optional FORCED_FORM_ERROR handling
- Update server action tests for mock environment and forced error cases

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac39adefd0832997e51c0bffeccc09