### PR TITLE
refactor: simplify test env detection

### DIFF
--- a/lib/server-actions.ts
+++ b/lib/server-actions.ts
@@ -81,8 +81,6 @@ async function handleFormSubmission<T>(
   status?: number;
 }> {
   const isTest =
-    process.env.NODE_ENV === "test" ||
-    process.env.TEST_MODE === "true" ||
     process.env.MOCK_DB === "true" ||
     process.env.MOCK_EMAIL === "true";
   if (isTest) {


### PR DESCRIPTION
## Summary
- simplify test mode detection using `MOCK_DB` and `MOCK_EMAIL` flags
- drop use of `NODE_ENV` and `TEST_MODE` in `handleFormSubmission`

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac573b37ec8329a7fdf086d790b85a