### PR TITLE
chore: remove obsolete test env vars

### DIFF
--- a/e2e/forms.spec.ts
+++ b/e2e/forms.spec.ts
@@ -304,7 +304,7 @@ test.describe("Contact Forms", () => {
     await unroute();
   });
 
-  test.use({ env: { FORCED_FORM_ERROR: "true" } as any });
+  test.use({ env: { FORCED_FORM_ERROR: "true" } });
 
   test("should handle form submission errors gracefully", async () => {
     expect(true).toBe(true);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,8 +56,6 @@ export default defineConfig({
       DB_PASSWORD: "test_password",
       MOCK_DB: "true",
       MOCK_EMAIL: "true",
-      TEST_MODE: "true",
-      FORCED_FORM_ERROR: "true",
       ADMIN_USER: "admin",
       ADMIN_PASS: "password",
       NEXT_PUBLIC_ADMIN_USER: "admin",


### PR DESCRIPTION
## Summary
- remove FORCED_FORM_ERROR and TEST_MODE from Playwright webServer env
- set FORCED_FORM_ERROR via test.use in forms e2e test

## Testing
- `npm test`
- `npm run build`
- `npx playwright test e2e/forms.spec.ts --grep "should handle form submission errors gracefully"` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/webkit-2191/pw_run.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68ac617027188329895f6f7f60e16e1a