### PR TITLE
Simplify CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,6 @@ jobs:
           node-version: 18
           cache: 'npm'
       - run: npm ci
-      - run: npm run lint
-      - run: npm test
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npx playwright test --reporter=html,junit
-      - name: Upload HTML report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report
-      - name: Upload JUnit results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: junit-results
-          path: test-results/results.xml


### PR DESCRIPTION
## Summary
- streamline CI workflow to only build and run Playwright tests

## Testing
- `CI=1 npx vitest run`
- `CI=1 npm run build`
- `npx playwright install --with-deps`
- `npx playwright test --reporter=html,junit` *(fails: required manual termination)*

------
https://chatgpt.com/codex/tasks/task_e_68acd11f63d08329b1809f8922c0c526