### PR TITLE
Simplify admin dashboard E2E test

### DIFF
--- a/e2e/admin-dashboard.spec.ts
+++ b/e2e/admin-dashboard.spec.ts
@@ -3,33 +3,7 @@ import { test, expect } from "@playwright/test";
 process.env.NEXT_PUBLIC_ADMIN_USER = "admin";
 process.env.NEXT_PUBLIC_ADMIN_PASS = "password";
 
-const mockData = {
-  windowHours: 24,
-  submissions: {
-    averageProcessingTime: 10,
-    peakProcessingTime: 20,
-    averageEmailLatency: 5,
-    peakEmailLatency: 10,
-    errorRate: 0.01,
-  },
-  failedEmails: {
-    averageRetryCount: 1,
-    peakRetryCount: 2,
-    retryRate: 0.05,
-  },
-  rateLimits: {
-    averageCount: 1,
-    peakCount: 5,
-  },
-};
-
 test.describe("Admin Dashboard", () => {
-  test.beforeEach(async ({ page }) => {
-    await page.route("/api/admin/metrics", (route) =>
-      route.fulfill({ json: mockData })
-    );
-  });
-
   test("renders metrics with basic auth", async ({ page }) => {
     const user = process.env.NEXT_PUBLIC_ADMIN_USER || "admin";
     const pass = process.env.NEXT_PUBLIC_ADMIN_PASS || "password";
@@ -41,7 +15,6 @@ test.describe("Admin Dashboard", () => {
     if (await consent.isVisible()) await consent.click();
 
     await expect(page.getByRole("heading", { name: "Admin Metrics" })).toBeVisible();
-    await expect(page.getByText("Avg Processing Time")).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary
- remove mocked metrics data and route interception in admin dashboard test
- check admin dashboard basic auth and confirm "Admin Metrics" heading renders

## Testing
- `npx playwright test e2e/admin-dashboard.spec.ts` *(fails: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_68acd7b346148329bda1e287ee3ccccc