### PR TITLE
test: add Playwright e2e helpers

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,0 +1,17 @@
+import { Page, Locator, expect } from '@playwright/test';
+
+export async function goto(page: Page, path = '/') {
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+}
+
+export async function dismissCookieBanner(page: Page) {
+  const btn = page.getByRole('button', { name: /akceptuj|accept/i });
+  if (await btn.isVisible().catch(() => false)) await btn.click();
+}
+
+export async function ensureSubmitVisible(form: Locator) {
+  const btn = form.locator('button[type="submit"]');
+  await expect(btn).toBeVisible();
+  await expect(btn).toBeEnabled();
+}
+


### PR DESCRIPTION
## Summary
- add helper utilities for Playwright e2e tests (navigation, cookie banner dismissal, submit button)

## Testing
- `npm run type-check` (fails: Property 'fn' does not exist on type 'typeof jest')
- `npx tsc --noEmit e2e/tests/helpers.ts`
- `npm test` (no test files found)


------
https://chatgpt.com/codex/tasks/task_e_68acfa944d7c83299fe22088e2a13561