### PR TITLE
Verify deploy URL secret before running smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,13 @@ jobs:
           remote_user: ${{ secrets.DEPLOY_USER }}
           remote_key: ${{ secrets.DEPLOY_SSH_KEY }}
 
+      - name: Verify deploy URL secret
+        if: ${{ !secrets.DEPLOY_URL }}
+        run: |
+          echo "Missing DEPLOY_URL secret"
+          exit 1
       - name: Smoke test
+        if: ${{ secrets.DEPLOY_URL }}
         run: |
           set -e
           curl -fsSL "${{ secrets.DEPLOY_URL }}" | grep -qi "<html"


### PR DESCRIPTION
## Summary
- check for missing DEPLOY_URL secret in deploy workflow
- run smoke test only when DEPLOY_URL is provided

## Testing
- `npm test -- --run` (fails: No test files found, exit 1)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adc8c94dc0832983202455b4d2d39c