### PR TITLE
chore: add lint type-check and unit test steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run lint
+      - run: npm run type-check
+      - run: npm test
+      - name: Upload unit test artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: |
+            coverage
+            test-results
       - run: npm run build
       - run: npx playwright install --with-deps
       - run: npx playwright test --reporter=html,junit


### PR DESCRIPTION
## Summary
- run lint, type-check, and unit tests in CI
- upload unit test results on failure

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'fn' does not exist on type 'typeof import("jest"...)')*
- `npm test` *(no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68adccd0cf98832989016b9a4d9fd77e