### PR TITLE
Enforce explicit admin auth configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ ANALYTICS_BASIC_USER=analytics-user
 ANALYTICS_BASIC_PASS=analytics-pass
 
 # Admin dashboard credentials and metrics window
+# Either supply a bearer token or basic auth credentials
+ADMIN_AUTH_TOKEN=change-me
 ADMIN_USER=admin
 ADMIN_PASS=change-me
 METRICS_WINDOW_HOURS=24

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Migrations are orchestrated by `scripts/migrate.ts` which executes all SQL files
 ### Admin Dashboard
 `ADMIN_USER`, `ADMIN_PASS`, `NEXT_PUBLIC_ADMIN_USER`, `NEXT_PUBLIC_ADMIN_PASS`, `METRICS_WINDOW_HOURS`
 
+At least one of `ADMIN_AUTH_TOKEN` or the `ADMIN_USER`/`ADMIN_PASS` pair must be set.
+
 ### Misc
 `CI`, `NODE_ENV`
 
@@ -55,8 +57,8 @@ Migrations are orchestrated by `scripts/migrate.ts` which executes all SQL files
 
 ## Admin Dashboard & Metrics
 
-- Navigate to `/admin/dashboard` to view submission and rate-limit metrics.  
-- Supply credentials via `ADMIN_USER` and `ADMIN_PASS` (or `NEXT_PUBLIC_ADMIN_USER`/`NEXT_PUBLIC_ADMIN_PASS` for prefilled prompts) to satisfy the HTTP Basic Auth check.
+- Navigate to `/admin/dashboard` to view submission and rate-limit metrics.
+- Access requires either a bearer token (`ADMIN_AUTH_TOKEN`) or HTTP Basic credentials (`ADMIN_USER`/`ADMIN_PASS`; `NEXT_PUBLIC_ADMIN_USER`/`NEXT_PUBLIC_ADMIN_PASS` prefill the prompt).
 - Metrics are served from `/api/admin/metrics` and include submission processing times, email retry stats, and rate‑limit counts.
 - Health checks are available at `/api/health` for infrastructure monitoring.
 

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,8 +1,14 @@
 import { type NextRequest, NextResponse } from "next/server";
 
-const TOKEN = process.env.ADMIN_AUTH_TOKEN || "dev-token";
+const TOKEN = process.env.ADMIN_AUTH_TOKEN;
 const BASIC_USER = process.env.ADMIN_USER;
 const BASIC_PASS = process.env.ADMIN_PASS;
+
+if (!TOKEN && !(BASIC_USER && BASIC_PASS)) {
+  throw new Error(
+    "Missing admin auth configuration: define ADMIN_AUTH_TOKEN or both ADMIN_USER and ADMIN_PASS",
+  );
+}
 
 function isTokenValid(header: string | null): boolean {
   if (!header || !TOKEN) return false;
@@ -19,9 +25,6 @@ export function requireAdminAuth(
   request: NextRequest,
 ): NextResponse | null {
   const header = request.headers.get("authorization");
-  if (!TOKEN && !(BASIC_USER && BASIC_PASS)) {
-    return null;
-  }
   if (isTokenValid(header) || isBasicValid(header)) {
     return null;
   }


### PR DESCRIPTION
## Summary
- require ADMIN_AUTH_TOKEN or ADMIN_USER/ADMIN_PASS to be set
- document admin auth env vars

## Testing
- `npm test` *(no tests found)*
- `npm run test:integration` *(fails: No test files found, exiting with code 1)*
- `npm run test:e2e` *(terminated during build)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68add165b52483299713c19f90d280fc