### PR TITLE
chore: harden csp

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import { cookies } from "next/headers"
+import Script from "next/script"
 import { LanguageProvider } from "@/components/language-provider"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { Toaster } from "@/components/ui/sonner"
@@ -93,27 +94,7 @@ export default function RootLayout({
         <link rel="manifest" href="/site.webmanifest" />
         <meta name="theme-color" content="#0f766e" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        {/* Matomo */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              var _paq = window._paq = window._paq || [];
-              _paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
-              _paq.push(["setCookieDomain", "*.gliwicka111.pl"]);
-              _paq.push(["setDomains", ["*.gliwicka111.pl"]]);
-              _paq.push(['trackPageView']);
-              _paq.push(['enableLinkTracking']);
-              (function() {
-                var u="//stats0.mydevil.net/";
-                _paq.push(['setTrackerUrl', u+'matomo.php']);
-                _paq.push(['setSiteId', '589']);
-                var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-                g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-              })();
-            `,
-          }}
-        />
-        {/* End Matomo Code */}
+        <Script src="/matomo.js" strategy="afterInteractive" />
       </head>
       <body className={inter.className}>
         <Toaster />

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,7 @@ import { requireAdminAuth } from '@/lib/admin-auth'
 
 const securityHeaders: Record<string, string> = {
   'Content-Security-Policy':
-    "default-src 'self'; img-src 'self' data: https://stats0.mydevil.net; script-src 'self' 'unsafe-inline' https://stats0.mydevil.net; style-src 'self' 'unsafe-inline'; font-src 'self'; connect-src 'self' https://stats0.mydevil.net;",
+    "default-src 'self'; img-src 'self' data: https://stats0.mydevil.net; script-src 'self' https://stats0.mydevil.net; style-src 'self'; font-src 'self'; connect-src 'self' https://stats0.mydevil.net;",
   'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
   'X-Frame-Options': 'DENY',
   'X-Content-Type-Options': 'nosniff',

--- a/public/matomo.js
+++ b/public/matomo.js
@@ -1,0 +1,13 @@
+var _paq = window._paq = window._paq || [];
+_paq.push(["setDocumentTitle", document.domain + "/" + document.title]);
+_paq.push(["setCookieDomain", "*.gliwicka111.pl"]);
+_paq.push(["setDomains", ["*.gliwicka111.pl"]]);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="//stats0.mydevil.net/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '589']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();


### PR DESCRIPTION
## Summary
- remove `'unsafe-inline'` from CSP
- move Matomo analytics to external script

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint`
- `curl -I http://localhost:3001/api/health`

------
https://chatgpt.com/codex/tasks/task_e_68ae11ca8e408329956cc094f0c03c7c