### PR TITLE
refactor: add analytics event row interface

### DIFF
--- a/app/api/analytics/export/route.ts
+++ b/app/api/analytics/export/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { requireAuth } from "@/lib/analytics-auth"
+import { type AnalyticsEventRow } from "@/lib/analytics-types"
 
 export async function GET(request: NextRequest) {
   const unauthorized = requireAuth(request)
@@ -37,7 +38,7 @@ export async function GET(request: NextRequest) {
 
     const { rows } = await db.query(query, params)
 
-    const sanitizedEvents = rows.map((event) => ({
+    const sanitizedEvents = rows.map((event: AnalyticsEventRow) => ({
       formType: event.formType,
       eventType: event.eventType,
       fieldName: event.fieldName,
@@ -48,7 +49,7 @@ export async function GET(request: NextRequest) {
 
     if (format === "csv") {
       const csvHeaders = ["formType", "eventType", "fieldName", "timestamp", "date", "language"]
-      const csvRows = sanitizedEvents.map((event) =>
+      const csvRows = sanitizedEvents.map((event: any) =>
         csvHeaders.map((header) => event[header as keyof typeof event] || "").join(","),
       )
       const csvContent = [csvHeaders.join(","), ...csvRows].join("\n")

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 import { z } from "zod"
 import { requireAuth } from "@/lib/analytics-auth"
 import { checkRateLimit } from "@/lib/rate-limit"
+import { type AnalyticsEventRow } from "@/lib/analytics-types"
 
 // Analytics event schema
 const analyticsEventSchema = z.object({
@@ -166,7 +167,7 @@ export async function GET(request: NextRequest) {
 
     const { rows } = await db.query(query, params)
 
-    const sanitizedEvents = rows.map((event) => ({
+    const sanitizedEvents = rows.map((event: AnalyticsEventRow) => ({
       formType: event.formType,
       eventType: event.eventType,
       fieldName: event.fieldName,

--- a/lib/analytics-types.ts
+++ b/lib/analytics-types.ts
@@ -1,0 +1,13 @@
+export interface AnalyticsEventRow {
+  formType: string
+  eventType: string
+  fieldName?: string | null
+  errorMessage?: string | null
+  timestamp: number
+  sessionId?: string | null
+  userAgent?: string | null
+  language?: string | null
+  formVersion?: string | null
+  ipHash?: string | null
+  receivedAt?: string | Date | null
+}


### PR DESCRIPTION
## Summary
- add shared `AnalyticsEventRow` interface
- type database rows in analytics export and tracking routes

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint`
- `npm run type-check` *(fails: missing jest typings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae26af1fd88329b91d021bc6ea0ec8