### PR TITLE
Handle optional field errors across forms

### DIFF
--- a/components/forms/advertising-form.tsx
+++ b/components/forms/advertising-form.tsx
@@ -247,7 +247,8 @@ export default function AdvertisingForm({ language = "pl" }: AdvertisingFormProp
     analytics.trackFieldBlur(fieldName)
   }
 
-  const handleFieldError = (fieldName: string, error: string) => {
+  const handleFieldError = (fieldName: string, error?: string) => {
+    if (!error) return
     analytics.trackFieldError(fieldName, error)
   }
 

--- a/components/forms/coworking-form.tsx
+++ b/components/forms/coworking-form.tsx
@@ -217,7 +217,8 @@ export default function CoworkingForm({ language = "pl" }: CoworkingFormProps) {
     analytics.trackFieldBlur(fieldName)
   }
 
-  const handleFieldError = (fieldName: string, error: string) => {
+  const handleFieldError = (fieldName: string, error?: string) => {
+    if (!error) return
     analytics.trackFieldError(fieldName, error)
   }
 

--- a/components/forms/meeting-room-form.tsx
+++ b/components/forms/meeting-room-form.tsx
@@ -260,7 +260,8 @@ export default function MeetingRoomForm({ language = "pl" }: MeetingRoomFormProp
     analytics.trackFieldBlur(fieldName)
   }
 
-  const handleFieldError = (fieldName: string, error: string) => {
+  const handleFieldError = (fieldName: string, error?: string) => {
+    if (!error) return
     analytics.trackFieldError(fieldName, error)
   }
 

--- a/components/forms/special-deals-form.tsx
+++ b/components/forms/special-deals-form.tsx
@@ -267,7 +267,8 @@ export default function SpecialDealsForm({ language = "pl" }: SpecialDealsFormPr
     analytics.trackFieldBlur(fieldName)
   }
 
-  const handleFieldError = (fieldName: string, error: string) => {
+  const handleFieldError = (fieldName: string, error?: string) => {
+    if (!error) return
     analytics.trackFieldError(fieldName, error)
   }
 

--- a/components/forms/virtual-office-form.tsx
+++ b/components/forms/virtual-office-form.tsx
@@ -251,7 +251,8 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
     analytics.trackFieldBlur(fieldName)
   }
 
-  const handleFieldError = (fieldName: string, error: string) => {
+  const handleFieldError = (fieldName: string, error?: string) => {
+    if (!error) return
     analytics.trackFieldError(fieldName, error)
   }
 


### PR DESCRIPTION
## Summary
- allow `handleFieldError` helpers in all form components to receive optional error strings
- avoid analytics tracking when no error message is provided

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae28324fd48329a5da23604fad1f46