### PR TITLE
refactor: load analytics dashboard with explicit default export

### DIFF
--- a/components/forms/form-showcase.tsx
+++ b/components/forms/form-showcase.tsx
@@ -24,7 +24,10 @@ import { ConsentBanner } from "@/components/analytics"
 import { Globe, MapPin, Users, Calendar, Megaphone, Gift, BarChart3, Shield } from "lucide-react"
 
 const AnalyticsDashboard = dynamic(
-  () => import("@/components/analytics/analytics-dashboard"),
+  () =>
+    import("@/components/analytics/analytics-dashboard").then(
+      (m) => m.default
+    ),
   { ssr: false }
 )
 


### PR DESCRIPTION
## Summary
- ensure AnalyticsDashboard dynamic import resolves default export explicitly

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae292f4f2c8329b980742e764a4aea