### PR TITLE
chore: type db connections

### DIFF
--- a/app/api/admin/metrics/route.ts
+++ b/app/api/admin/metrics/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { requireAdminAuth } from "@/lib/admin-auth";
+import type { Pool } from "pg";
 
 const METRICS_WINDOW_HOURS = Number(process.env.METRICS_WINDOW_HOURS || "24");
 
@@ -32,10 +33,10 @@ export async function GET(request: NextRequest) {
   const unauthorized = requireAdminAuth(request);
   if (unauthorized) return unauthorized;
 
-  let db;
+  let db: Pool;
   try {
     const { getPool } = await import("@/lib/database/connection-pool");
-    db = await getPool();
+    db = (await getPool()) as Pool;
   } catch {
     return NextResponse.json({ error: "Database connection failed" }, { status: 500 });
   }

--- a/app/api/analytics/export/route.ts
+++ b/app/api/analytics/export/route.ts
@@ -1,15 +1,16 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { requireAuth } from "@/lib/analytics-auth"
 import { type AnalyticsEventRow } from "@/lib/analytics-types"
+import type { Pool } from "pg"
 
 export async function GET(request: NextRequest) {
   const unauthorized = requireAuth(request)
   if (unauthorized) return unauthorized
   try {
     const { getPool } = await import("@/lib/database/connection-pool")
-    let db
+    let db: Pool
     try {
-      db = await getPool()
+      db = (await getPool()) as Pool
       await db.query("SELECT 1")
     } catch {
       return NextResponse.json({ error: "Database connection failed" }, { status: 500 })
@@ -36,9 +37,9 @@ export async function GET(request: NextRequest) {
       params.push(formType)
     }
 
-    const { rows } = await db.query(query, params)
+    const { rows } = await db.query<AnalyticsEventRow>(query, params)
 
-    const sanitizedEvents = rows.map((event: AnalyticsEventRow) => ({
+    const sanitizedEvents = rows.map((event) => ({
       formType: event.formType,
       eventType: event.eventType,
       fieldName: event.fieldName,

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import { requireAuth } from "@/lib/analytics-auth"
 import { checkRateLimit } from "@/lib/rate-limit"
 import { type AnalyticsEventRow } from "@/lib/analytics-types"
+import type { Pool } from "pg"
 
 // Analytics event schema
 const analyticsEventSchema = z.object({
@@ -67,9 +68,9 @@ export async function POST(request: NextRequest) {
   if (unauthorized) return unauthorized
   try {
     const { getPool } = await import("@/lib/database/connection-pool")
-    let db
+    let db: Pool
     try {
-      db = await getPool()
+      db = (await getPool()) as Pool
       await db.query("SELECT 1")
     } catch {
       return NextResponse.json({ error: "Database connection failed" }, { status: 500 })
@@ -131,9 +132,9 @@ export async function GET(request: NextRequest) {
   if (unauthorized) return unauthorized
   try {
     const { getPool } = await import("@/lib/database/connection-pool")
-    let db
+    let db: Pool
     try {
-      db = await getPool()
+      db = (await getPool()) as Pool
       await db.query("SELECT 1")
     } catch {
       return NextResponse.json({ error: "Database connection failed" }, { status: 500 })
@@ -165,9 +166,9 @@ export async function GET(request: NextRequest) {
     query += ` ORDER BY timestamp DESC LIMIT $${params.length + 1}`
     params.push(limit)
 
-    const { rows } = await db.query(query, params)
+    const { rows } = await db.query<AnalyticsEventRow>(query, params)
 
-    const sanitizedEvents = rows.map((event: AnalyticsEventRow) => ({
+    const sanitizedEvents = rows.map((event) => ({
       formType: event.formType,
       eventType: event.eventType,
       fieldName: event.fieldName,

--- a/lib/admin/metrics.ts
+++ b/lib/admin/metrics.ts
@@ -1,8 +1,9 @@
 import { getPool } from "@/lib/database/connection-pool";
+import type { Pool } from "pg";
 
-async function getDb() {
+async function getDb(): Promise<Pool> {
   try {
-    return await getPool();
+    return (await getPool()) as Pool;
   } catch (error) {
     console.error("Database connection error", error);
     throw error;
@@ -10,7 +11,7 @@ async function getDb() {
 }
 
 export async function getSubmissionMetrics() {
-  const db = await getDb();
+  const db = (await getDb()) as Pool;
   const result = await db.query<{
     avg_processing_time_ms: number | null;
     avg_email_latency_ms: number | null;
@@ -26,7 +27,7 @@ export async function getSubmissionMetrics() {
 }
 
 export async function getDuplicateAttemptCount() {
-  const db = await getDb();
+  const db = (await getDb()) as Pool;
   const result = await db.query<{ count: string }>(
     `SELECT COUNT(*)::text AS count FROM duplicate_attempts`,
   );

--- a/lib/database/connection-pool.ts
+++ b/lib/database/connection-pool.ts
@@ -1,12 +1,8 @@
 import { Pool } from "pg";
 
-type Queryable = {
-  query: (...args: any[]) => Promise<any>;
-};
+let pool: Pool | null = null;
 
-let pool: (Pool | Queryable) | null = null;
-
-async function createPool(): Promise<Pool | Queryable> {
+async function createPool(): Promise<Pool> {
   const {
     DB_HOST,
     DB_PORT,
@@ -20,7 +16,7 @@ async function createPool(): Promise<Pool | Queryable> {
   if (MOCK_DB === "true" || (!DB_HOST && !DATABASE_URL)) {
     return {
       query: async () => ({ rows: [], rowCount: 0 }),
-    };
+    } as unknown as Pool;
   }
 
   const instance = DATABASE_URL
@@ -53,7 +49,7 @@ async function createPool(): Promise<Pool | Queryable> {
   return instance;
 }
 
-export async function getPool(): Promise<Pool | Queryable> {
+export async function getPool(): Promise<Pool> {
   if (!pool) {
     try {
       pool = await createPool();

--- a/lib/monitoring/health-check.ts
+++ b/lib/monitoring/health-check.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import type { Pool } from "pg"
 
 interface HealthCheckResult {
   service: string
@@ -78,7 +79,7 @@ export class HealthCheckService {
 
     try {
       const { getPool } = await import("@/lib/database/connection-pool")
-      const db = await getPool()
+      const db = (await getPool()) as Pool
       await db.query("SELECT 1")
 
       return {

--- a/lib/testing/integration-setup.ts
+++ b/lib/testing/integration-setup.ts
@@ -1,7 +1,7 @@
 import { vi, beforeAll, afterAll, beforeEach, afterEach } from "vitest"
 import "@testing-library/jest-dom"
 import { cleanup } from "@testing-library/react"
-import { Client } from "pg"
+import { Client, type Pool } from "pg"
 import { readFile } from "node:fs/promises"
 import path from "node:path"
 
@@ -27,7 +27,7 @@ vi.mock("@/lib/database/connection-pool", () => {
     query: vi.fn(),
     transaction: vi.fn(),
   }
-  const getPool = vi.fn().mockResolvedValue(db)
+  const getPool = vi.fn().mockResolvedValue(db as unknown as Pool)
   return { getPool, default: getPool }
 })
 


### PR DESCRIPTION
## Summary
- return `Promise<Pool>` from `getPool`
- cast pooled connections to `Pool` and use typed `db.query`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Property 'fn' does not exist on type 'typeof import("jest")')*
- `npm run test:unit` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2b40c0f48329ba9a91dd582de9a6