### PR TITLE
Annotate pool error handler

### DIFF
--- a/lib/database/connection-pool.ts
+++ b/lib/database/connection-pool.ts
@@ -34,7 +34,7 @@ async function createPool(): Promise<Pool> {
         max: 20,
       });
 
-  instance.on("error", (err) => {
+  instance.on("error", (err: Error) => {
     console.error("Database connection error", err);
     throw err;
   });


### PR DESCRIPTION
## Summary
- annotate database connection pool error event handler parameter as `Error`

## Testing
- `npm test` *(fails: no test files found)*
- `npm run lint`
- `npm run type-check` *(fails: TS2339: Property 'fn' does not exist on type 'typeof import("jest")')*

------
https://chatgpt.com/codex/tasks/task_e_68ae2d71426883298ef14c6f5b53a988