### PR TITLE
Declare global gtag and use optional invocation in form utils

### DIFF
--- a/lib/form-utils.ts
+++ b/lib/form-utils.ts
@@ -4,6 +4,12 @@ import type React from "react"
 
 import type { FieldError } from "react-hook-form"
 
+declare global {
+  interface Window {
+    gtag?: (...args: any[]) => void
+  }
+}
+
 // Form field validation utilities
 export const validateField = (value: string, rules: ValidationRule[]): string | null => {
   for (const rule of rules) {
@@ -106,8 +112,8 @@ export const trackFormInteraction = (
   fieldName?: string,
   metadata?: Record<string, any>,
 ) => {
-  if (typeof window !== "undefined" && window.gtag) {
-    window.gtag("event", eventType, {
+  if (typeof window !== "undefined") {
+    window.gtag?.("event", eventType, {
       form_type: formType,
       field_name: fieldName,
       ...metadata,


### PR DESCRIPTION
## Summary
- declare `window.gtag` type globally
- call `window.gtag?.()` in `trackFormInteraction`

## Testing
- `npm test -- --run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2eaed4448329ab666827144a6d67