### PR TITLE
fix: handle optional deploy URL secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      DEPLOY_URL: ${{ secrets.DEPLOY_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,12 +41,13 @@ jobs:
           remote_key: ${{ secrets.DEPLOY_SSH_KEY }}
 
       - name: Verify deploy URL secret
-        if: ${{ secrets.DEPLOY_URL }}
+        if: ${{ env.DEPLOY_URL == '' }}
         run: |
           echo "Missing DEPLOY_URL secret"
           exit 1
+
       - name: Smoke test
-        if: ${{ secrets.DEPLOY_URL }}
+        if: ${{ env.DEPLOY_URL != '' }}
         run: |
           set -e
-          curl -fsSL "${{ secrets.DEPLOY_URL }}" | grep -qi "<html"
+          curl -fsSL "$DEPLOY_URL" | grep -qi "<html"


### PR DESCRIPTION
## Summary
- use job env to expose DEPLOY_URL
- guard deploy job steps when URL secret is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae41c50b208329918ed092f7523368