### PR TITLE
docs: add quality checks guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ At least one of `ADMIN_AUTH_TOKEN` or the `ADMIN_USER`/`ADMIN_PASS` pair must be
 - **Unit & Integration Tests**: `npm test`, `npm run test:integration` (Vitest).
 - **End-to-End Tests**: `npm run test:e2e` (Playwright).
 - **Linting**: `npm run lint` (Next.js ESLint).
-- **Continuous Integration**: GitHub Actions workflow `ci.yml` runs lint, tests, and build on every push/PR.  
+- **Continuous Integration**: GitHub Actions workflow `ci.yml` runs lint, tests, and build on every push/PR.
 - **End-to-End & Deployment Pipelines**: `e2e.yml` executes Playwright tests, while `deploy.yml` ships builds to MyDevil (FreeBSD) after successful E2E runs.
+- For detailed linting, testing, and security audit steps, see [Quality checks](./docs/quality.md).
 
 ## Deployment
 

--- a/docs/quality.md
+++ b/docs/quality.md
@@ -1,0 +1,70 @@
+# Quality checks
+
+This guide covers linting, testing, and security audits for the project.
+
+## Linting
+
+Run ESLint to check code quality:
+
+```bash
+npm run lint
+```
+
+Automatically fix issues:
+
+```bash
+npm run lint:fix
+```
+
+## Testing
+
+### Unit & Integration Tests
+
+Run the standard unit test suite:
+
+```bash
+npm test
+```
+
+Integration tests use a separate configuration:
+
+```bash
+npm run test:integration
+```
+
+### End-to-End Tests (Playwright)
+
+1. Install Playwright dependencies once:
+   ```bash
+   npx playwright install --with-deps
+   ```
+2. Provide required environment variables when running the tests:
+   - `BASE_URL` – base URL of the running app (defaults to `http://localhost:3000`)
+   - `NEXT_PUBLIC_ADMIN_USER` – admin username for HTTP Basic Auth
+   - `NEXT_PUBLIC_ADMIN_PASS` – admin password for HTTP Basic Auth
+
+Example:
+
+```bash
+BASE_URL=http://localhost:3000 \
+NEXT_PUBLIC_ADMIN_USER=admin \
+NEXT_PUBLIC_ADMIN_PASS=admin \
+npm run test:e2e
+```
+
+The script builds the app and then executes the Playwright test suite.
+
+## Security Audit
+
+Check for vulnerable dependencies:
+
+```bash
+npm run security:audit
+```
+
+Attempt automatic fixes:
+
+```bash
+npm run security:fix
+```
+


### PR DESCRIPTION
## Summary
- document lint, test, and security audit commands
- include Playwright setup and required environment variables
- link quality checks guide from README

## Testing
- `npm test -- --run` *(fails: No test files found)*
- `npm run lint`
- `npm run security:audit`


------
https://chatgpt.com/codex/tasks/task_e_68ae3f26527883298369cc1ca872b443