### PR TITLE
refactor: defer admin auth env checks

### DIFF
--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -4,12 +4,6 @@ const TOKEN = process.env.ADMIN_AUTH_TOKEN;
 const BASIC_USER = process.env.ADMIN_USER;
 const BASIC_PASS = process.env.ADMIN_PASS;
 
-if (!TOKEN && !(BASIC_USER && BASIC_PASS)) {
-  throw new Error(
-    "Missing admin auth configuration: define ADMIN_AUTH_TOKEN or both ADMIN_USER and ADMIN_PASS",
-  );
-}
-
 function isTokenValid(header: string | null): boolean {
   if (!header || !TOKEN) return false;
   return header === `Bearer ${TOKEN}`;
@@ -17,13 +11,24 @@ function isTokenValid(header: string | null): boolean {
 
 function isBasicValid(header: string | null): boolean {
   if (!header || !BASIC_USER || !BASIC_PASS) return false;
-  const expected = Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString("base64");
+  const expected = Buffer.from(`${BASIC_USER}:${BASIC_PASS}`).toString(
+    "base64",
+  );
   return header === `Basic ${expected}`;
 }
 
-export function requireAdminAuth(
-  request: NextRequest,
-): NextResponse | null {
+export function requireAdminAuth(request: NextRequest): NextResponse | null {
+  if (process.env.NODE_ENV === "development") {
+    return null;
+  }
+
+  if (!TOKEN && !(BASIC_USER && BASIC_PASS)) {
+    console.warn(
+      "Missing admin auth configuration: define ADMIN_AUTH_TOKEN or both ADMIN_USER and ADMIN_PASS",
+    );
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const header = request.headers.get("authorization");
   if (isTokenValid(header) || isBasicValid(header)) {
     return null;


### PR DESCRIPTION
## Summary
- defer admin auth configuration checks until `requireAdminAuth` is invoked
- log warnings and return 401 when config is missing instead of throwing on import
- allow skipping admin auth in development environments

## Testing
- `npm test -- --run` *(fails: No test files found, exiting with code 1)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed30707c88329bb15239554abd590