### PR TITLE
fix: type annotations for virtual office features

### DIFF
--- a/components/forms/virtual-office-form.tsx
+++ b/components/forms/virtual-office-form.tsx
@@ -220,7 +220,8 @@ export default function VirtualOfficeForm({ language = "pl" }: VirtualOfficeForm
 
       {/* Package Selection */}
       <div className="grid md:grid-cols-3 gap-6 mb-8">
-        {Object.entries(t.packages).map(([key, pkg]) => (
+        {Object.entries(t.packages).map(
+          ([key, pkg]: [string, { name: string; price: string; features: readonly string[] }]) => (
           <Card key={key} className="relative hover:shadow-lg transition-shadow">
             <CardHeader className="text-center">
               <CardTitle className="text-lg">{pkg.name}</CardTitle>


### PR DESCRIPTION
## Summary
- specify tuple and feature types in VirtualOfficeForm package rendering

## Testing
- `npm run type-check`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d678df0883298d9de8e6c37ad2a5