### PR TITLE
Fix standalone deployment missing static assets

### DIFF
--- a/DEPLOYMENT_PM2_MYDEVIL.md
+++ b/DEPLOYMENT_PM2_MYDEVIL.md
@@ -9,7 +9,7 @@
    ```bash
    npm ci
    ```
-3. Build production bundle (copies static assets into `.next/standalone`):
+3. Build production bundle (copies `public`, `.next/static` and `tmp` into `.next/standalone`):
    ```bash
    npm run build
    ```

--- a/scripts/prepare-standalone.js
+++ b/scripts/prepare-standalone.js
@@ -25,6 +25,7 @@ async function main() {
 
   await copy(safeJoin(root, 'public'), safeJoin(standalone, 'public'));
   await copy(safeJoin(root, '.next', 'static'), safeJoin(standalone, '.next', 'static'));
+  await copy(safeJoin(root, 'tmp'), safeJoin(standalone, 'tmp'));
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- copy `public`, `.next/static`, and `tmp` into `.next/standalone`
- document that `tmp` directory is included in standalone build

## Testing
- `npx vitest run`
- `npm run lint` *(warning: The 'logE2E' function makes the dependencies of useEffect Hook change on every render)*

------
https://chatgpt.com/codex/tasks/task_e_68c339db5b608329953d0fd3a1ac5dc2