### PR TITLE
Add server env vars to example and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 # Example environment variables for local development and Vercel
 
+# Server configuration (optional)
+HOSTNAME=0.0.0.0
+PORT=3000
+
 # Database connection for form submissions and health checks
 DB_HOST=localhost
 DB_PORT=5432
@@ -18,6 +22,9 @@ SMTP_USER=username
 SMTP_PASS=password
 SMTP_FROM=no-reply@example.com
 ADMIN_EMAIL=admin@example.com
+# Optional email testing and retries
+MOCK_EMAIL=false
+EMAIL_MAX_RETRIES=3
 
 # Security
 # Strong random value for hashing IP addresses (e.g., `openssl rand -hex 32`)
@@ -43,7 +50,3 @@ RATE_LIMIT_WINDOW_MS=60000
 # Misc
 CI=false
 NODE_ENV=development
-# Example environment variables
-# Salt used to hash IP addresses for privacy-friendly analytics and rate limiting.
-# Generate with: `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
-IP_SALT=

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Migrations are orchestrated by `scripts/migrate.ts` which executes all SQL files
 
 ## Environment Variables
 
+### Server
+
+`HOSTNAME`, `PORT`
+
 ### Database
 
 `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DATABASE_URL`, `MOCK_DB`

--- a/WARP.md
+++ b/WARP.md
@@ -118,19 +118,22 @@ npm run retry:failed-emails
 
 The application requires several environment variables categorized by function:
 
-1. **Database Configuration**
+1. **Server Settings**
+   - Optional: `HOSTNAME`, `PORT`
+
+2. **Database Configuration**
    - Required: `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`
    - Optional: `DATABASE_URL`, `MOCK_DB`
 
-2. **Email Service**
+3. **Email Service**
    - Required: `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`
    - Optional: `SMTP_FROM`, `EMAIL_MAX_RETRIES`, `MOCK_EMAIL`
 
-3. **Security Settings**
+4. **Security Settings**
    - Required: `IP_SALT`, `ADMIN_AUTH_TOKEN`
    - Optional: `RATE_LIMIT_COUNT`, `RATE_LIMIT_WINDOW_MS`
 
-4. **Analytics & Admin Access**
+5. **Analytics & Admin Access**
    - Required: `ANALYTICS_AUTH_TOKEN`, `ADMIN_USER`, `ADMIN_PASS`
    - Optional: `NEXT_PUBLIC_ANALYTICS_TOKEN`, `METRICS_WINDOW_HOURS`
 


### PR DESCRIPTION
## Summary
- add optional HOSTNAME and PORT entries
- expose MOCK_EMAIL and EMAIL_MAX_RETRIES
- drop duplicate IP_SALT and document new env vars

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c71a808ee883299f313380bf852398