### PR TITLE
chore: remove hardcoded NODE_ENV

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,9 +5,8 @@ module.exports = {
       // Run the Next.js production server via npm
       script: "npm",
       args: "start",
-      env: {
-        NODE_ENV: "production"
-      },
+      // Environment variables like PORT, HOSTNAME, and NODE_ENV should
+      // be provided by the hosting environment, not within this file.
       autorestart: true,
       watch: false,
       max_memory_restart: "400M",


### PR DESCRIPTION
## Summary
- let environment manage NODE_ENV and other runtime variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c71c3170988329ac30f7489c2e7efc