### PR TITLE
Refactor static pages to server components

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,15 +1,8 @@
-"use client";
-
-import { useState } from "react";
-import { useLanguage } from "@/components/language-provider";
 import {
   Building2,
   MapPin,
   Phone,
   Mail,
-  Menu,
-  X,
-  Globe,
   ArrowLeft,
   Target,
   Users,
@@ -20,6 +13,8 @@ import { Button, Card, CardContent } from "@/components/ui";
 import Link from "next/link";
 import Image from "next/image";
 import { navTranslations, backTranslations } from "@/lib/i18n";
+import { PageNav } from "@/components/page-nav";
+import { getCurrentLanguage } from "@/lib/get-current-language";
 
 const translations = {
   pl: {
@@ -142,10 +137,10 @@ const translations = {
   },
 };
 
-export default function AboutPage() {
-  const { language, toggleLanguage } = useLanguage();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+export const dynamic = "force-static";
 
+export default async function AboutPage() {
+  const language = await getCurrentLanguage();
   const t = translations[language];
 
   const values = [
@@ -173,114 +168,7 @@ export default function AboutPage() {
 
   return (
     <div className="min-h-screen bg-white">
-      {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-100 sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            {/* Logo */}
-            <div className="flex items-center space-x-2">
-              <div className="w-10 h-10 bg-gradient-to-br from-slate-700 to-slate-900 rounded-lg flex items-center justify-center">
-                <Building2 className="w-6 h-6 text-white" />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold text-slate-900">
-                  Gliwicka 111
-                </h1>
-                <p className="text-xs text-slate-600">Property Management</p>
-              </div>
-            </div>
-
-            {/* Desktop Navigation */}
-            <nav className="hidden md:flex items-center space-x-8">
-              <Link
-                href="/"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.home}
-              </Link>
-              <Link
-                href="/properties"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.properties}
-              </Link>
-              <Link href="/about" className="text-teal-600 font-medium">
-                {t.nav.about}
-              </Link>
-              <Link
-                href="/contact"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.contact}
-              </Link>
-
-              {/* Language Switcher */}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={toggleLanguage}
-                className="flex items-center space-x-1 bg-transparent"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language.toUpperCase()}</span>
-              </Button>
-            </nav>
-
-            {/* Mobile Menu Button */}
-            <div className="md:hidden flex items-center space-x-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={toggleLanguage}
-                className="flex items-center space-x-1 bg-transparent"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language.toUpperCase()}</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              >
-                {mobileMenuOpen ? (
-                  <X className="w-5 h-5" />
-                ) : (
-                  <Menu className="w-5 h-5" />
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {/* Mobile Menu */}
-          {mobileMenuOpen && (
-            <div className="md:hidden border-t border-gray-100 py-4">
-              <nav className="flex flex-col space-y-4">
-                <Link
-                  href="/"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.home}
-                </Link>
-                <Link
-                  href="/properties"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.properties}
-                </Link>
-                <Link href="/about" className="text-teal-600 font-medium">
-                  {t.nav.about}
-                </Link>
-                <Link
-                  href="/contact"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.contact}
-                </Link>
-              </nav>
-            </div>
-          )}
-        </div>
-      </header>
+      <PageNav nav={t.nav} current="about" />
 
       {/* Hero Section */}
       <section className="bg-gradient-to-br from-slate-50 to-white py-16">

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import { useState } from "react";
-import { useLanguage } from "@/components/language-provider";
-import { Building2, Globe, Menu, X, ArrowLeft } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import {
   Button,
   Card,
@@ -12,6 +8,8 @@ import {
 } from "@/components/ui";
 import Link from "next/link";
 import { navTranslations, backTranslations } from "@/lib/i18n";
+import { PageNav } from "@/components/page-nav";
+import { getCurrentLanguage } from "@/lib/get-current-language";
 
 const translations = {
   pl: {
@@ -180,128 +178,15 @@ const translations = {
   },
 };
 
-export default function PrivacyPage() {
-  const { language, toggleLanguage } = useLanguage();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+export const dynamic = "force-static";
 
+export default async function PrivacyPage() {
+  const language = await getCurrentLanguage();
   const t = translations[language];
 
   return (
     <div className="min-h-screen bg-white">
-      {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-100 sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            {/* Logo */}
-            <div className="flex items-center space-x-2">
-              <div className="w-10 h-10 bg-gradient-to-br from-slate-700 to-slate-900 rounded-lg flex items-center justify-center">
-                <Building2 className="w-6 h-6 text-white" />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold text-slate-900">
-                  Gliwicka 111
-                </h1>
-                <p className="text-xs text-slate-600">Property Management</p>
-              </div>
-            </div>
-
-            {/* Desktop Navigation */}
-            <nav className="hidden md:flex items-center space-x-8">
-              <Link
-                href="/"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.home}
-              </Link>
-              <Link
-                href="/properties"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.properties}
-              </Link>
-              <Link
-                href="/about"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.about}
-              </Link>
-              <Link
-                href="/contact"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.contact}
-              </Link>
-
-              {/* Language Switcher */}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={toggleLanguage}
-                className="flex items-center space-x-1 bg-transparent"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language.toUpperCase()}</span>
-              </Button>
-            </nav>
-
-            {/* Mobile Menu Button */}
-            <div className="md:hidden flex items-center space-x-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={toggleLanguage}
-                className="flex items-center space-x-1 bg-transparent"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language.toUpperCase()}</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              >
-                {mobileMenuOpen ? (
-                  <X className="w-5 h-5" />
-                ) : (
-                  <Menu className="w-5 h-5" />
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {/* Mobile Menu */}
-          {mobileMenuOpen && (
-            <div className="md:hidden border-t border-gray-100 py-4">
-              <nav className="flex flex-col space-y-4">
-                <Link
-                  href="/"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.home}
-                </Link>
-                <Link
-                  href="/properties"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.properties}
-                </Link>
-                <Link
-                  href="/about"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.about}
-                </Link>
-                <Link
-                  href="/contact"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.contact}
-                </Link>
-              </nav>
-            </div>
-          )}
-        </div>
-      </header>
+      <PageNav nav={t.nav} />
 
       {/* Content */}
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,8 +1,4 @@
-"use client";
-
-import { useState } from "react";
-import { useLanguage } from "@/components/language-provider";
-import { Building2, Globe, Menu, X, ArrowLeft } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import {
   Button,
   Card,
@@ -12,6 +8,8 @@ import {
 } from "@/components/ui";
 import Link from "next/link";
 import { navTranslations, backTranslations } from "@/lib/i18n";
+import { PageNav } from "@/components/page-nav";
+import { getCurrentLanguage } from "@/lib/get-current-language";
 
 const translations = {
   pl: {
@@ -191,128 +189,15 @@ const translations = {
   },
 };
 
-export default function TermsPage() {
-  const { language, toggleLanguage } = useLanguage();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+export const dynamic = "force-static";
 
+export default async function TermsPage() {
+  const language = await getCurrentLanguage();
   const t = translations[language];
 
   return (
     <div className="min-h-screen bg-white">
-      {/* Header */}
-      <header className="bg-white shadow-sm border-b border-gray-100 sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            {/* Logo */}
-            <div className="flex items-center space-x-2">
-              <div className="w-10 h-10 bg-gradient-to-br from-slate-700 to-slate-900 rounded-lg flex items-center justify-center">
-                <Building2 className="w-6 h-6 text-white" />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold text-slate-900">
-                  Gliwicka 111
-                </h1>
-                <p className="text-xs text-slate-600">Property Management</p>
-              </div>
-            </div>
-
-            {/* Desktop Navigation */}
-            <nav className="hidden md:flex items-center space-x-8">
-              <Link
-                href="/"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.home}
-              </Link>
-              <Link
-                href="/properties"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.properties}
-              </Link>
-              <Link
-                href="/about"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.about}
-              </Link>
-              <Link
-                href="/contact"
-                className="text-slate-700 hover:text-teal-600 font-medium transition-colors"
-              >
-                {t.nav.contact}
-              </Link>
-
-              {/* Language Switcher */}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={toggleLanguage}
-                className="flex items-center space-x-1 bg-transparent"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language.toUpperCase()}</span>
-              </Button>
-            </nav>
-
-            {/* Mobile Menu Button */}
-            <div className="md:hidden flex items-center space-x-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={toggleLanguage}
-                className="flex items-center space-x-1 bg-transparent"
-              >
-                <Globe className="w-4 h-4" />
-                <span>{language.toUpperCase()}</span>
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              >
-                {mobileMenuOpen ? (
-                  <X className="w-5 h-5" />
-                ) : (
-                  <Menu className="w-5 h-5" />
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {/* Mobile Menu */}
-          {mobileMenuOpen && (
-            <div className="md:hidden border-t border-gray-100 py-4">
-              <nav className="flex flex-col space-y-4">
-                <Link
-                  href="/"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.home}
-                </Link>
-                <Link
-                  href="/properties"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.properties}
-                </Link>
-                <Link
-                  href="/about"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.about}
-                </Link>
-                <Link
-                  href="/contact"
-                  className="text-slate-700 hover:text-teal-600 font-medium"
-                >
-                  {t.nav.contact}
-                </Link>
-              </nav>
-            </div>
-          )}
-        </div>
-      </header>
+      <PageNav nav={t.nav} />
 
       {/* Content */}
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-16">

--- a/components/page-nav.tsx
+++ b/components/page-nav.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { useLanguage } from "@/components/language-provider";
+import { Building2, Globe, Menu, X } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui";
+
+interface NavTranslations {
+  home: string;
+  properties: string;
+  about: string;
+  contact: string;
+}
+
+interface PageNavProps {
+  nav: NavTranslations;
+  current?: "home" | "properties" | "about" | "contact";
+}
+
+export function PageNav({ nav, current }: PageNavProps) {
+  const { language, toggleLanguage } = useLanguage();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const linkClass = (key: keyof NavTranslations) =>
+    current === key
+      ? "text-teal-600 font-medium"
+      : "text-slate-700 hover:text-teal-600 font-medium";
+
+  return (
+    <header className="border-b border-gray-100 sticky top-0 bg-white/80 backdrop-blur z-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center py-4 md:py-6">
+          <div className="flex items-center space-x-2">
+            <Building2 className="w-8 h-8 text-teal-600" />
+            <span className="text-xl font-bold text-slate-900">Gliwicka 111</span>
+          </div>
+          <nav className="hidden md:flex space-x-8">
+            <Link href="/" className={linkClass("home")}>
+              {nav.home}
+            </Link>
+            <Link href="/properties" className={linkClass("properties")}>
+              {nav.properties}
+            </Link>
+            <Link href="/about" className={linkClass("about")}>
+              {nav.about}
+            </Link>
+            <Link href="/contact" className={linkClass("contact")}>
+              {nav.contact}
+            </Link>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleLanguage}
+              className="flex items-center space-x-1 bg-transparent"
+            >
+              <Globe className="w-4 h-4" />
+              <span>{language.toUpperCase()}</span>
+            </Button>
+          </nav>
+          <div className="md:hidden flex items-center space-x-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleLanguage}
+              className="flex items-center space-x-1 bg-transparent"
+            >
+              <Globe className="w-4 h-4" />
+              <span>{language.toUpperCase()}</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            >
+              {mobileMenuOpen ? (
+                <X className="w-5 h-5" />
+              ) : (
+                <Menu className="w-5 h-5" />
+              )}
+            </Button>
+          </div>
+        </div>
+        {mobileMenuOpen && (
+          <div className="md:hidden border-t border-gray-100 py-4">
+            <nav className="flex flex-col space-y-4">
+              <Link href="/" className="text-slate-700 hover:text-teal-600 font-medium">
+                {nav.home}
+              </Link>
+              <Link
+                href="/properties"
+                className="text-slate-700 hover:text-teal-600 font-medium"
+              >
+                {nav.properties}
+              </Link>
+              <Link
+                href="/about"
+                className={linkClass("about")}
+              >
+                {nav.about}
+              </Link>
+              <Link
+                href="/contact"
+                className="text-slate-700 hover:text-teal-600 font-medium"
+              >
+                {nav.contact}
+              </Link>
+            </nav>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}
+
+export default PageNav;
+


### PR DESCRIPTION
## Summary
- extract interactive navigation and language toggle into new `PageNav` client component
- convert About, Terms, and Privacy pages to async server components using `getCurrentLanguage`
- force static pre-rendering for these pages

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c71fe820b88329aa191619063694c1