### PR TITLE
feat: add form API routes

### DIFF
--- a/app/api/forms/advertising/route.ts
+++ b/app/api/forms/advertising/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { advertisingFormSchema } from "@/lib/validation-schemas";
+import { messages } from "@/lib/i18n";
+
+function formDataToObject(fd: FormData): Record<string, any> {
+  const obj: Record<string, any> = {};
+  for (const [key, value] of fd.entries()) {
+    if (obj[key] !== undefined) {
+      if (Array.isArray(obj[key])) {
+        (obj[key] as any[]).push(value);
+      } else {
+        obj[key] = [obj[key], value];
+      }
+    } else {
+      obj[key] = value;
+    }
+  }
+  return obj;
+}
+
+export async function POST(req: Request) {
+  try {
+    const fd = await req.formData();
+    const data = formDataToObject(fd);
+
+    const processed: Record<string, any> = {
+      ...data,
+      gdprConsent: ["on", "true", "1"].includes(String(data.gdprConsent)),
+      marketingConsent: ["on", "true", "1"].includes(
+        String(data.marketingConsent),
+      ),
+      previousExperience: ["on", "true", "1"].includes(
+        String(data.previousExperience),
+      ),
+      campaignGoals: ([] as string[]).concat(
+        Array.isArray(data.campaignGoals)
+          ? data.campaignGoals
+          : data.campaignGoals
+            ? [data.campaignGoals]
+            : [],
+      ),
+    };
+
+    const parsed = advertisingFormSchema.safeParse(processed);
+    if (!parsed.success) {
+      const errors: Record<string, string> = {};
+      for (const err of parsed.error.errors) {
+        errors[err.path.join(".")] = err.message;
+      }
+      const lang: "pl" | "en" = "pl";
+      return NextResponse.json(
+        {
+          success: false,
+          message: messages.form.validationError[lang],
+          errors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: true, message: messages.form.success[lang] },
+      { status: 200 },
+    );
+  } catch (e) {
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: false, message: messages.form.serverError[lang] },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/forms/coworking/route.ts
+++ b/app/api/forms/coworking/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { coworkingFormSchema } from "@/lib/validation-schemas";
+import { messages } from "@/lib/i18n";
+
+function formDataToObject(fd: FormData): Record<string, any> {
+  const obj: Record<string, any> = {};
+  for (const [key, value] of fd.entries()) {
+    if (obj[key] !== undefined) {
+      if (Array.isArray(obj[key])) {
+        (obj[key] as any[]).push(value);
+      } else {
+        obj[key] = [obj[key], value];
+      }
+    } else {
+      obj[key] = value;
+    }
+  }
+  return obj;
+}
+
+export async function POST(req: Request) {
+  try {
+    const fd = await req.formData();
+    const data = formDataToObject(fd);
+
+    const processed: Record<string, any> = {
+      ...data,
+      gdprConsent: ["on", "true", "1"].includes(String(data.gdprConsent)),
+      marketingConsent: ["on", "true", "1"].includes(
+        String(data.marketingConsent),
+      ),
+      trialDay: ["on", "true", "1"].includes(String(data.trialDay)),
+      teamSize:
+        data.teamSize !== undefined && !Number.isNaN(Number(data.teamSize))
+          ? Number(data.teamSize)
+          : data.teamSize,
+    };
+
+    const parsed = coworkingFormSchema.safeParse(processed);
+    if (!parsed.success) {
+      const errors: Record<string, string> = {};
+      for (const err of parsed.error.errors) {
+        errors[err.path.join(".")] = err.message;
+      }
+      const lang: "pl" | "en" = "pl";
+      return NextResponse.json(
+        {
+          success: false,
+          message: messages.form.validationError[lang],
+          errors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: true, message: messages.form.success[lang] },
+      { status: 200 },
+    );
+  } catch (e) {
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: false, message: messages.form.serverError[lang] },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/forms/meeting-room/route.ts
+++ b/app/api/forms/meeting-room/route.ts
@@ -1,0 +1,76 @@
+import { NextResponse } from "next/server";
+import { meetingRoomFormSchema } from "@/lib/validation-schemas";
+import { messages } from "@/lib/i18n";
+
+function formDataToObject(fd: FormData): Record<string, any> {
+  const obj: Record<string, any> = {};
+  for (const [key, value] of fd.entries()) {
+    if (obj[key] !== undefined) {
+      if (Array.isArray(obj[key])) {
+        (obj[key] as any[]).push(value);
+      } else {
+        obj[key] = [obj[key], value];
+      }
+    } else {
+      obj[key] = value;
+    }
+  }
+  return obj;
+}
+
+export async function POST(req: Request) {
+  try {
+    const fd = await req.formData();
+    const data = formDataToObject(fd);
+
+    const processed: Record<string, any> = {
+      ...data,
+      gdprConsent: ["on", "true", "1"].includes(String(data.gdprConsent)),
+      marketingConsent: ["on", "true", "1"].includes(
+        String(data.marketingConsent),
+      ),
+      catering: ["on", "true", "1"].includes(String(data.catering)),
+      recurring: ["on", "true", "1"].includes(String(data.recurring)),
+      equipment: ([] as string[]).concat(
+        Array.isArray(data.equipment)
+          ? data.equipment
+          : data.equipment
+            ? [data.equipment]
+            : [],
+      ),
+      attendees:
+        data.attendees !== undefined && !Number.isNaN(Number(data.attendees))
+          ? Number(data.attendees)
+          : data.attendees,
+    };
+
+    const parsed = meetingRoomFormSchema.safeParse(processed);
+    if (!parsed.success) {
+      const errors: Record<string, string> = {};
+      for (const err of parsed.error.errors) {
+        errors[err.path.join(".")] = err.message;
+      }
+      const lang: "pl" | "en" = "pl";
+      return NextResponse.json(
+        {
+          success: false,
+          message: messages.form.validationError[lang],
+          errors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: true, message: messages.form.success[lang] },
+      { status: 200 },
+    );
+  } catch (e) {
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: false, message: messages.form.serverError[lang] },
+      { status: 500 },
+    );
+  }
+}

--- a/app/api/forms/special-deals/route.ts
+++ b/app/api/forms/special-deals/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { specialDealsFormSchema } from "@/lib/validation-schemas";
+import { messages } from "@/lib/i18n";
+
+function formDataToObject(fd: FormData): Record<string, any> {
+  const obj: Record<string, any> = {};
+  for (const [key, value] of fd.entries()) {
+    if (obj[key] !== undefined) {
+      if (Array.isArray(obj[key])) {
+        (obj[key] as any[]).push(value);
+      } else {
+        obj[key] = [obj[key], value];
+      }
+    } else {
+      obj[key] = value;
+    }
+  }
+  return obj;
+}
+
+export async function POST(req: Request) {
+  try {
+    const fd = await req.formData();
+    const data = formDataToObject(fd);
+
+    const processed: Record<string, any> = {
+      ...data,
+      gdprConsent: ["on", "true", "1"].includes(String(data.gdprConsent)),
+      marketingConsent: ["on", "true", "1"].includes(
+        String(data.marketingConsent),
+      ),
+      interestedServices: ([] as string[]).concat(
+        Array.isArray(data.interestedServices)
+          ? data.interestedServices
+          : data.interestedServices
+            ? [data.interestedServices]
+            : [],
+      ),
+    };
+
+    const parsed = specialDealsFormSchema.safeParse(processed);
+    if (!parsed.success) {
+      const errors: Record<string, string> = {};
+      for (const err of parsed.error.errors) {
+        errors[err.path.join(".")] = err.message;
+      }
+      const lang: "pl" | "en" = "pl";
+      return NextResponse.json(
+        {
+          success: false,
+          message: messages.form.validationError[lang],
+          errors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: true, message: messages.form.success[lang] },
+      { status: 200 },
+    );
+  } catch (e) {
+    const lang: "pl" | "en" = "pl";
+    return NextResponse.json(
+      { success: false, message: messages.form.serverError[lang] },
+      { status: 500 },
+    );
+  }
+}

--- a/tests/forms-api.test.ts
+++ b/tests/forms-api.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { POST as coworkingHandler } from "@/app/api/forms/coworking/route";
+import { POST as meetingRoomHandler } from "@/app/api/forms/meeting-room/route";
+import { POST as advertisingHandler } from "@/app/api/forms/advertising/route";
+import { POST as specialDealsHandler } from "@/app/api/forms/special-deals/route";
+
+function toRequest(data: Record<string, any>) {
+  const fd = new FormData();
+  Object.entries(data).forEach(([k, v]) => {
+    if (Array.isArray(v)) {
+      v.forEach((val) => fd.append(k, String(val)));
+    } else if (v !== undefined) {
+      fd.append(k, String(v));
+    }
+  });
+  return new Request("http://localhost", { method: "POST", body: fd });
+}
+
+describe("form API handlers", () => {
+  it("coworking accepts valid data", async () => {
+    const req = toRequest({
+      firstName: "Jan",
+      lastName: "Kowalski",
+      email: "jan@example.com",
+      phone: "+48 123 123 123",
+      gdprConsent: "true",
+      workspaceType: "hot-desk",
+      duration: "daily",
+      startDate: "2024-01-01",
+      teamSize: "1",
+    });
+    const res = await coworkingHandler(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+  });
+
+  it("meeting-room accepts valid data", async () => {
+    const req = toRequest({
+      firstName: "Jan",
+      lastName: "Kowalski",
+      email: "jan@example.com",
+      phone: "+48 123 123 123",
+      gdprConsent: "true",
+      roomType: "small",
+      date: "2024-01-01",
+      startTime: "10:00",
+      endTime: "11:00",
+      attendees: "1",
+    });
+    const res = await meetingRoomHandler(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+  });
+
+  it("advertising accepts valid data", async () => {
+    const req = toRequest({
+      firstName: "Jan",
+      lastName: "Kowalski",
+      email: "jan@example.com",
+      phone: "+48 123 123 123",
+      gdprConsent: "true",
+      campaignType: "mobile-billboard",
+      duration: "1-week",
+      startDate: "2024-01-01",
+      budget: "under-1000",
+    });
+    const res = await advertisingHandler(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+  });
+
+  it("special-deals accepts valid data", async () => {
+    const req = toRequest({
+      firstName: "Jan",
+      lastName: "Kowalski",
+      email: "jan@example.com",
+      phone: "+48 123 123 123",
+      gdprConsent: "true",
+      dealType: "welcome-package",
+      interestedServices: ["virtual-office"],
+      currentSituation: "new-business",
+      timeline: "immediate",
+    });
+    const res = await specialDealsHandler(req);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+  });
+});

--- a/tests/health-check.test.ts
+++ b/tests/health-check.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { HealthCheckService } from "@/lib/monitoring/health-check";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("health check form endpoints", () => {
+  it("checks all form endpoints", async () => {
+    const service = HealthCheckService.getInstance();
+    const mockResponse = new Response(null, { status: 405 });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch" as any)
+      .mockResolvedValue(mockResponse as any);
+
+    const result = await (service as any).checkFormSubmissionEndpoint();
+
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(result.status).toBe("healthy");
+    expect(result.details.endpoints).toEqual([
+      "/api/forms/virtual-office",
+      "/api/forms/coworking",
+      "/api/forms/meeting-room",
+      "/api/forms/advertising",
+      "/api/forms/special-deals",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add API handlers for coworking, meeting room, advertising and special deals forms
- implement health check for all form endpoints
- cover new routes and health check with unit tests

## Testing
- `CI=true npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c72c3410e0832986077fffe743fa6c