### PR TITLE
refactor: centralize env access

### DIFF
--- a/app/api/admin/metrics/route.ts
+++ b/app/api/admin/metrics/route.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { requireAdminAuth } from "@/lib/admin-auth";
 import type { Pool } from "pg";
+import { getEnv } from "@/lib/env";
 
-const METRICS_WINDOW_HOURS = Number(process.env.METRICS_WINDOW_HOURS || "24");
+const METRICS_WINDOW_HOURS = Number(getEnv("METRICS_WINDOW_HOURS", "24"));
 
 interface SubmissionRow {
   hour: Date;

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { requireAuth } from "@/lib/analytics-auth";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { type AnalyticsEventRow } from "@/lib/analytics-types";
+import { hashIP } from "@/lib/security/ip";
 import type { Pool } from "pg";
 
 // Analytics event schema
@@ -27,25 +28,6 @@ const analyticsEventSchema = z.object({
   language: z.string(),
   formVersion: z.string().optional(),
 });
-
-// Hash IP for privacy
-async function hashIP(ip: string): Promise<string> {
-  const crypto = await import("crypto");
-  const salt = process.env.IP_SALT;
-  if (!salt) {
-    const message = "IP_SALT environment variable is not set";
-    if (process.env.NODE_ENV === "production") {
-      throw new Error(message);
-    } else {
-      console.warn(message);
-    }
-  }
-  return crypto
-    .createHash("sha256")
-    .update(ip + (salt || "default-salt"))
-    .digest("hex")
-    .substring(0, 16);
-}
 
 // Get client IP
 function getClientIP(request: NextRequest): string {

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { getEnv, isProd } from "@/lib/env";
 
 function isTokenValid(header: string | null, token?: string): boolean {
   if (!header || !token) return false;
@@ -16,13 +17,13 @@ function isBasicValid(
 }
 
 export function requireAdminAuth(request: NextRequest): NextResponse | null {
-  if (process.env.NODE_ENV === "development") {
+  if (!isProd) {
     return null;
   }
 
-  const token = process.env.ADMIN_AUTH_TOKEN;
-  const user = process.env.ADMIN_USER;
-  const pass = process.env.ADMIN_PASS;
+  const token = getEnv("ADMIN_AUTH_TOKEN", "");
+  const user = getEnv("ADMIN_USER", "");
+  const pass = getEnv("ADMIN_PASS", "");
 
   if (!token && !(user && pass)) {
     console.warn(

--- a/lib/analytics-auth.ts
+++ b/lib/analytics-auth.ts
@@ -1,8 +1,9 @@
 import { type NextRequest, NextResponse } from "next/server";
+import { getEnv } from "@/lib/env";
 
-const TOKEN = process.env.ANALYTICS_AUTH_TOKEN || "dev-token";
-const BASIC_USER = process.env.ANALYTICS_BASIC_USER;
-const BASIC_PASS = process.env.ANALYTICS_BASIC_PASS;
+const TOKEN = getEnv("ANALYTICS_AUTH_TOKEN", "dev-token");
+const BASIC_USER = getEnv("ANALYTICS_BASIC_USER", "");
+const BASIC_PASS = getEnv("ANALYTICS_BASIC_PASS", "");
 
 function isTokenValid(header: string | null): boolean {
   if (!header || !TOKEN) return false;

--- a/lib/database/connection-pool.ts
+++ b/lib/database/connection-pool.ts
@@ -1,17 +1,16 @@
 import { Pool } from "pg";
+import { getEnv } from "@/lib/env";
 
 let pool: Pool | null = null;
 
 async function createPool(): Promise<Pool> {
-  const {
-    DB_HOST,
-    DB_PORT,
-    DB_NAME,
-    DB_USER,
-    DB_PASSWORD,
-    MOCK_DB,
-    DATABASE_URL,
-  } = process.env;
+  const DB_HOST = getEnv("DB_HOST", "");
+  const DB_PORT = getEnv("DB_PORT", "");
+  const DB_NAME = getEnv("DB_NAME", "");
+  const DB_USER = getEnv("DB_USER", "");
+  const DB_PASSWORD = getEnv("DB_PASSWORD", "");
+  const MOCK_DB = getEnv("MOCK_DB", "");
+  const DATABASE_URL = getEnv("DATABASE_URL", "");
 
   if (MOCK_DB === "true" || (!DB_HOST && !DATABASE_URL)) {
     return {

--- a/lib/email/retry.ts
+++ b/lib/email/retry.ts
@@ -8,10 +8,11 @@ import {
   sendAdminNotification,
 } from "@/lib/server-actions";
 import { emailClient } from "./smtp-client";
+import { getEnv } from "@/lib/env";
 
 export async function processFailedEmails() {
-  const MAX_RETRIES = Number(process.env.EMAIL_MAX_RETRIES || 3);
-  const ADMIN_EMAIL = process.env.ADMIN_EMAIL || "admin@gliwicka111.pl";
+  const MAX_RETRIES = Number(getEnv("EMAIL_MAX_RETRIES", "3"));
+  const ADMIN_EMAIL = getEnv("ADMIN_EMAIL", "admin@gliwicka111.pl");
   const failures = await getPendingFailedEmails();
   for (const failure of failures) {
     try {

--- a/lib/monitoring/health-check.ts
+++ b/lib/monitoring/health-check.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import type { Pool } from "pg";
+import { getEnv } from "@/lib/env";
 
 interface HealthCheckResult {
   service: string;
@@ -27,7 +28,7 @@ interface SystemHealth {
 export class HealthCheckService {
   private static instance: HealthCheckService;
   private startTime: number = Date.now();
-  private version: string = process.env.npm_package_version || "1.0.0";
+  private version: string = getEnv("npm_package_version", "1.0.0");
 
   static getInstance(): HealthCheckService {
     if (!HealthCheckService.instance) {
@@ -117,8 +118,8 @@ export class HealthCheckService {
         responseTime: performance.now() - startTime,
         message: "Email service connection successful",
         details: {
-          smtpHost: process.env.SMTP_HOST,
-          smtpPort: process.env.SMTP_PORT,
+          smtpHost: getEnv("SMTP_HOST", ""),
+          smtpPort: getEnv("SMTP_PORT", ""),
         },
         timestamp: new Date().toISOString(),
       };
@@ -271,7 +272,7 @@ export class HealthCheckService {
 
   private async checkFormSubmissionEndpoint(): Promise<HealthCheckResult> {
     const startTime = performance.now();
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    const baseUrl = getEnv("NEXT_PUBLIC_APP_URL", "http://localhost:3000");
     const endpoints = [
       "/api/forms/virtual-office",
       "/api/forms/coworking",

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,8 +1,10 @@
+import { getEnv } from "@/lib/env";
+
 export async function checkRateLimit(
   db: any,
   identifier: string,
-  limit = Number(process.env.RATE_LIMIT_COUNT ?? "100"),
-  windowMs = Number(process.env.RATE_LIMIT_WINDOW_MS ?? "60000"),
+  limit = Number(getEnv("RATE_LIMIT_COUNT", "100")),
+  windowMs = Number(getEnv("RATE_LIMIT_WINDOW_MS", "60000")),
 ): Promise<boolean> {
   const now = Date.now();
   const { rows } = await db.query(

--- a/lib/security/ip.ts
+++ b/lib/security/ip.ts
@@ -1,17 +1,22 @@
+import { getEnv, isProd } from "@/lib/env";
+
 export async function hashIP(ip: string): Promise<string> {
   const crypto = await import("crypto");
-  const salt = process.env.IP_SALT;
-  if (!salt) {
+  let salt: string;
+  try {
+    salt = getEnv("IP_SALT");
+  } catch {
     const message = "IP_SALT environment variable is not set";
-    if (process.env.NODE_ENV === "production") {
+    if (isProd) {
       throw new Error(message);
     } else {
       console.warn(message);
+      salt = "default-salt";
     }
   }
   return crypto
     .createHash("sha256")
-    .update(ip + (salt || "default-salt"))
+    .update(ip + salt)
     .digest("hex")
     .substring(0, 16);
 }

--- a/lib/server-actions.ts
+++ b/lib/server-actions.ts
@@ -24,15 +24,16 @@ import { messages } from "./i18n";
 import { getCurrentLanguage } from "./get-current-language";
 import { hashIP } from "./security/ip";
 import { checkRateLimit } from "./rate-limit";
+import { getEnv } from "@/lib/env";
 
 // Email service configuration
 const EMAIL_CONFIG = {
-  from: process.env.SMTP_FROM || "noreply@gliwicka111.pl",
-  adminEmail: process.env.ADMIN_EMAIL || "admin@gliwicka111.pl",
-  smtpHost: process.env.SMTP_HOST || "smtp.gmail.com",
-  smtpPort: Number.parseInt(process.env.SMTP_PORT || "587"),
-  smtpUser: process.env.SMTP_USER,
-  smtpPass: process.env.SMTP_PASS,
+  from: getEnv("SMTP_FROM", "noreply@gliwicka111.pl"),
+  adminEmail: getEnv("ADMIN_EMAIL", "admin@gliwicka111.pl"),
+  smtpHost: getEnv("SMTP_HOST", "smtp.gmail.com"),
+  smtpPort: Number.parseInt(getEnv("SMTP_PORT", "587"), 10),
+  smtpUser: getEnv("SMTP_USER", ""),
+  smtpPass: getEnv("SMTP_PASS", ""),
 };
 
 // Service names mapping for admin notifications
@@ -90,10 +91,11 @@ async function handleFormSubmission<T>(
   status?: number;
 }> {
   const isTest =
-    process.env.MOCK_DB === "true" || process.env.MOCK_EMAIL === "true";
+    getEnv("MOCK_DB", "false") === "true" ||
+    getEnv("MOCK_EMAIL", "false") === "true";
   if (isTest) {
     const lang = await getCurrentLanguage();
-    if (process.env.FORCED_FORM_ERROR === "true") {
+    if (getEnv("FORCED_FORM_ERROR", "false") === "true") {
       return { success: false, message: messages.form.serverError[lang] };
     }
     return { success: true, message: messages.form.success[lang] };
@@ -104,8 +106,8 @@ async function handleFormSubmission<T>(
     const clientIP = getClientIP();
     const ipHash = await hashIP(clientIP);
 
-    const rateLimitCount = Number(process.env.RATE_LIMIT_COUNT ?? "100");
-    const rateLimitWindow = Number(process.env.RATE_LIMIT_WINDOW_MS ?? "60000");
+    const rateLimitCount = Number(getEnv("RATE_LIMIT_COUNT", "100"));
+    const rateLimitWindow = Number(getEnv("RATE_LIMIT_WINDOW_MS", "60000"));
     let db: Pool;
     try {
       db = (await getDb()) as Pool;

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,13 +1,10 @@
 import { readdir, readFile } from "fs/promises";
 import path from "path";
 import { Client } from "pg";
+import { getEnv } from "../lib/env";
 
 async function runMigrations() {
-  const dbUrl = process.env.DATABASE_URL;
-  if (!dbUrl) {
-    console.error("DATABASE_URL is not set");
-    process.exit(1);
-  }
+  const dbUrl = getEnv("DATABASE_URL");
 
   const client = new Client({ connectionString: dbUrl });
   await client.connect();


### PR DESCRIPTION
## Summary
- use shared `getEnv` helper for SMTP and server actions
- enforce `getEnv` across rate limiting, auth, and monitoring utilities
- ensure scripts and API routes read env vars via `getEnv`

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c72f10bba883299adae1a5399e1515