### PR TITLE
refactor: add CSP nonce for scripts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import type { Metadata } from "next";
 // Removed next/font/google to avoid network fetch during build/tests
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import Script from "next/script";
 import { LanguageProvider } from "@/components/language-provider";
 import { ErrorBoundary } from "@/components/error-boundary";
@@ -82,6 +82,7 @@ export default function RootLayout({
   const cookieLang = cookieStore.get("lang")?.value === "en" ? "en" : "pl";
   const currentLanguage =
     params?.lang === "en" || params?.lang === "pl" ? params.lang : cookieLang;
+  const nonce = headers().get("x-nonce") || undefined;
 
   return (
     <html lang={currentLanguage}>
@@ -107,7 +108,7 @@ export default function RootLayout({
         <link rel="manifest" href="/site.webmanifest" />
         <meta name="theme-color" content="#0f766e" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <Script src="/matomo.js" strategy="afterInteractive" />
+        <Script src="/matomo.js" strategy="afterInteractive" nonce={nonce} />
       </head>
       <body
         className="font-sans"


### PR DESCRIPTION
## Summary
- strengthen CSP by removing `unsafe-inline` in production and using per-request nonces
- tag layout analytics script with the generated nonce

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c8101c6e848329a6c0a9eae12a33b7