### PR TITLE
Remove passWithNoTests from vitest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "security:audit": "npm audit --audit-level moderate",
     "security:fix": "npm audit fix",
     "start": "next start",
-    "test": "vitest --passWithNoTests",
+    "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "cross-env NEXT_PUBLIC_E2E=true npm run build && playwright test -c e2e/playwright.config.ts",
     "test:e2e:freeport": "node scripts/free-port.js | xargs -I {} sh -c 'TEST_PORT={} cross-env NEXT_PUBLIC_E2E=true npm run build && TEST_PORT={} playwright test -c e2e/playwright.config.ts'",


### PR DESCRIPTION
## Summary
- remove the `--passWithNoTests` flag from the `npm test` script so Vitest will fail when it finds no test files
- confirm that the existing CI workflow runs `npm test`, allowing builds to surface missing test suites

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8400f563c8329b711f1ebf5454cfc