### PR TITLE
Update deploy workflow fallback URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PORT: 3000
-      DEPLOY_URL: ${{ secrets.DEPLOY_URL != '' && secrets.DEPLOY_URL || format('http://127.0.0.1:{0}', env.PORT) }}
+      DEPLOY_URL: ${{ secrets.DEPLOY_URL != '' && secrets.DEPLOY_URL || 'http://127.0.0.1:3000' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update the deploy workflow to use a static localhost fallback for `DEPLOY_URL` while keeping the secret override behavior

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68c86fd5ecfc8329878370b0daf1a0fe