### PR TITLE
Adjust deploy URL fallback handling

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PORT: 3000
-      DEPLOY_URL: ${{ secrets.DEPLOY_URL != '' && secrets.DEPLOY_URL || 'http://127.0.0.1:3000' }}
+      DEPLOY_URL: ${{ secrets.DEPLOY_URL != '' && secrets.DEPLOY_URL || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,6 +21,10 @@ jobs:
         with:
           node-version: 20
           cache: npm
+
+      - name: Set fallback DEPLOY_URL
+        if: ${{ env.DEPLOY_URL == '' }}
+        run: echo "DEPLOY_URL=http://127.0.0.1:${PORT}" >> $GITHUB_ENV
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- defer the DEPLOY_URL fallback assignment so it no longer references env.PORT in the job-level definition
- populate a fallback URL via GITHUB_ENV when no secret value is available while keeping the secret value prioritized

## Testing
- No tests were run (not applicable for workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c91cb6f2408329bdc5fe44a3c108f4