### PR TITLE
Use e2e Playwright config in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             test-results
       - run: npm run build
       - run: npx playwright install --with-deps
-      - run: npx playwright test --reporter=html,junit
+      - run: npx playwright test -c e2e/playwright.config.ts --reporter=html,junit
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- update the CI workflow to execute Playwright with the dedicated e2e configuration so the tests in e2e/tests run

## Testing
- MOCK_DB=true npx playwright test -c e2e/playwright.config.ts --reporter=html,junit *(fails: /api/health returns healthy)*

------
https://chatgpt.com/codex/tasks/task_e_68c92e4e901883298eafbe85f7e8a1fb