### PR TITLE
Adjust health check for optional dependencies in tests

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,7 +1,16 @@
+import { type NextRequest } from "next/server";
+
 import { healthCheck } from "@/lib/monitoring/health-check";
 
 export async function GET(request: Request) {
-  return healthCheck.createHealthCheckEndpoint(request as any);
+  const skipOptionalChecks =
+    process.env.HEALTHCHECK_SKIP_OPTIONAL === "true" ||
+    process.env.NEXT_PUBLIC_E2E === "true" ||
+    process.env.NODE_ENV === "test";
+
+  return healthCheck.createHealthCheckEndpoint(request as NextRequest, {
+    skipOptionalChecks,
+  });
 }
 
 export const dynamic = "force-dynamic";


### PR DESCRIPTION
## Summary
- ensure the health route flags optional checks to be skipped during e2e runs
- allow the health check service to skip optional dependencies when requested or via test env vars
- short-circuit optional checks with a healthy result so missing services do not fail the endpoint

## Testing
- `npx playwright test -c e2e/playwright.config.ts --reporter=html,junit` *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9594b0d9883298d11478f8e330707