### PR TITLE
Fix deploy workflow heredoc termination

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -273,7 +273,7 @@ jobs:
                 echo "pm2 not found on remote host. Showing recent Node processes:"
                 ps -ef | grep node || true
               fi
-              EOSSH
+          EOSSH
               then
                 echo "Remote diagnostics collected successfully."
               else


### PR DESCRIPTION
## Summary
- Align the remote log collection heredoc terminator so the shell can parse the EOSSH marker correctly.

## Testing
- ~/.local/bin/yamllint -d "{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}" .github/workflows/deploy.yml

------
https://chatgpt.com/codex/tasks/task_e_68c9690dfce883298ce37697fbc4c71b