### PR TITLE
Fix echo formatting in database inspection workflows

### DIFF
--- a/.github/workflows/db-inspect.yml
+++ b/.github/workflows/db-inspect.yml
@@ -42,10 +42,8 @@ jobs:
             LOOKBACK_MINUTES="${{ inputs.lookback_minutes }}"
             echo "-- Checking last $LOOKBACK_MINUTES minutes --"
 
-            echo "
-== failed_emails (recent) =="
+            echo "== failed_emails (recent) =="
             psql -v ON_ERROR_STOP=1 -t -A -F $'	' "$DATABASE_URL" -c               "SELECT id, email_type, status, retry_count, to_char(created_at,'YYYY-MM-DD HH24:MI:SS') AS created_at FROM failed_emails WHERE created_at >= NOW() - ($LOOKBACK_MINUTES || ' minutes')::interval ORDER BY created_at DESC LIMIT 20;" || true
 
-            echo "
-== form_submissions (recent) =="
+            echo "== form_submissions (recent) =="
             psql -v ON_ERROR_STOP=1 -t -A -F $'	' "$DATABASE_URL" -c               "SELECT id, form_type, status, to_char(created_at,'YYYY-MM-DD HH24:MI:SS') AS created_at FROM form_submissions WHERE created_at >= NOW() - ($LOOKBACK_MINUTES || ' minutes')::interval ORDER BY created_at DESC LIMIT 20;" || true

--- a/.github/workflows/smtp-diag.yml
+++ b/.github/workflows/smtp-diag.yml
@@ -123,9 +123,7 @@ jobs:
             fi
             LOOKBACK_MINUTES="180"
             echo "-- Checking last $LOOKBACK_MINUTES minutes --"
-            echo "
-== failed_emails (recent) =="
+            echo "== failed_emails (recent) =="
             psql -v ON_ERROR_STOP=1 -t -A -F $'	' "$DATABASE_URL" -c "SELECT id, email_type, status, retry_count, to_char(created_at,'YYYY-MM-DD HH24:MI:SS') AS created_at FROM failed_emails WHERE created_at >= NOW() - ($LOOKBACK_MINUTES || ' minutes')::interval ORDER BY created_at DESC LIMIT 20;" || true
-            echo "
-== form_submissions (recent) =="
+            echo "== form_submissions (recent) =="
             psql -v ON_ERROR_STOP=1 -t -A -F $'	' "$DATABASE_URL" -c "SELECT id, form_type, status, to_char(created_at,'YYYY-MM-DD HH24:MI:SS') AS created_at FROM form_submissions WHERE created_at >= NOW() - ($LOOKBACK_MINUTES || ' minutes')::interval ORDER BY created_at DESC LIMIT 20;" || true


### PR DESCRIPTION
## Summary
- collapse multiline echo strings in the DB inspection scripts so they stay on one line for valid YAML quoting

## Testing
- actionlint

------
https://chatgpt.com/codex/tasks/task_e_68d6fa43db08832998e361d7c0cefbe6