### PR TITLE
Fix formatting of DB check echo lines in SMTP diag workflow

### DIFF
--- a/.github/workflows/smtp-diag.yml
+++ b/.github/workflows/smtp-diag.yml
@@ -122,7 +122,7 @@ jobs:
               fi
             fi
             LOOKBACK_MINUTES="180"
-            echo "-- Checking last $LOOKBACK_MINUTES minutes --"
+            echo "-- Checking last ${LOOKBACK_MINUTES} minutes --"
             echo "== failed_emails (recent) =="
             psql -v ON_ERROR_STOP=1 -t -A -F $'	' "$DATABASE_URL" -c "SELECT id, email_type, status, retry_count, to_char(created_at,'YYYY-MM-DD HH24:MI:SS') AS created_at FROM failed_emails WHERE created_at >= NOW() - ($LOOKBACK_MINUTES || ' minutes')::interval ORDER BY created_at DESC LIMIT 20;" || true
             echo "== form_submissions (recent) =="


### PR DESCRIPTION
## Summary
- ensure the DB check echo statement stays on one line to keep indentation correct

## Testing
- /tmp/actionlint

------
https://chatgpt.com/codex/tasks/task_e_68d6fb28e014832982fb79e24b00c7e2