### PR TITLE
Replace footer badge with logo image

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -343,11 +343,21 @@ export default async function AboutPage() {
           <div className="grid md:grid-cols-4 gap-8">
             {/* Company Info */}
             <div className="md:col-span-2">
-              <div className="flex items-center space-x-2 mb-4">
-                <div className="w-10 h-10 bg-gradient-to-br from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
-                  <Building2 className="w-6 h-6 text-white" />
-                </div>
-                <div>
+              <div className="mb-4">
+                <Link
+                  href="/"
+                  className="inline-flex items-center hover:opacity-80 transition-opacity"
+                  aria-label="Gliwicka 111 — Property Management"
+                >
+                  <Image
+                    src="/gliwicka111.png"
+                    alt="Gliwicka 111 — Property Management"
+                    width={200}
+                    height={40}
+                    className="h-10 w-auto"
+                  />
+                </Link>
+                <div className="mt-3">
                   <h3 className="text-xl font-bold">Gliwicka 111</h3>
                   <p className="text-sm text-slate-400">Property Management</p>
                 </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -5,7 +5,6 @@ import type React from "react";
 import { useState } from "react";
 import { useLanguage } from "@/components/language-provider";
 import {
-  Building2,
   MapPin,
   Phone,
   Mail,
@@ -28,6 +27,7 @@ import {
   Label,
 } from "@/components/ui";
 import Link from "next/link";
+import Image from "next/image";
 import { navTranslations, backTranslations } from "@/lib/i18n";
 import PageNav from "@/components/page-nav";
 
@@ -555,11 +555,21 @@ export default function ContactPage() {
           <div className="grid md:grid-cols-4 gap-8">
             {/* Company Info */}
             <div className="md:col-span-2">
-              <div className="flex items-center space-x-2 mb-4">
-                <div className="w-10 h-10 bg-gradient-to-br from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
-                  <Building2 className="w-6 h-6 text-white" />
-                </div>
-                <div>
+              <div className="mb-4">
+                <Link
+                  href="/"
+                  className="inline-flex items-center hover:opacity-80 transition-opacity"
+                  aria-label="Gliwicka 111 — Property Management"
+                >
+                  <Image
+                    src="/gliwicka111.png"
+                    alt="Gliwicka 111 — Property Management"
+                    width={200}
+                    height={40}
+                    className="h-10 w-auto"
+                  />
+                </Link>
+                <div className="mt-3">
                   <h3 className="text-xl font-bold">Gliwicka 111</h3>
                   <p className="text-sm text-slate-400">Property Management</p>
                 </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1899,11 +1899,21 @@ export default function HomePage() {
           <div className="grid md:grid-cols-5 gap-8">
             {/* Company Info */}
             <div className="md:col-span-2">
-              <div className="flex items-center space-x-2 mb-4">
-                <div className="w-10 h-10 bg-gradient-to-br from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
-                  <Building2 className="w-6 h-6 text-white" />
-                </div>
-                <div>
+              <div className="mb-4">
+                <Link
+                  href="/"
+                  className="inline-flex items-center hover:opacity-80 transition-opacity"
+                  aria-label="Gliwicka 111 — Property Management"
+                >
+                  <Image
+                    src="/gliwicka111.png"
+                    alt="Gliwicka 111 — Property Management"
+                    width={200}
+                    height={40}
+                    className="h-10 w-auto"
+                  />
+                </Link>
+                <div className="mt-3">
                   <h3 className="text-xl font-bold">{t.footer.company}</h3>
                   <p className="text-sm text-slate-400">Property Management</p>
                 </div>

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -376,11 +376,21 @@ export default function PropertiesPage() {
             <div className="grid md:grid-cols-4 gap-8">
               {/* Company Info */}
               <div className="md:col-span-2">
-                <div className="flex items-center space-x-2 mb-4">
-                  <div className="w-10 h-10 bg-gradient-to-br from-teal-500 to-teal-600 rounded-lg flex items-center justify-center">
-                    <Building2 className="w-6 h-6 text-white" />
-                  </div>
-                  <div>
+                <div className="mb-4">
+                  <Link
+                    href="/"
+                    className="inline-flex items-center hover:opacity-80 transition-opacity"
+                    aria-label="Gliwicka 111 — Property Management"
+                  >
+                    <Image
+                      src="/gliwicka111.png"
+                      alt="Gliwicka 111 — Property Management"
+                      width={200}
+                      height={40}
+                      className="h-10 w-auto"
+                    />
+                  </Link>
+                  <div className="mt-3">
                     <h3 className="text-xl font-bold">Gliwicka 111</h3>
                     <p className="text-sm text-slate-400">
                       Property Management


### PR DESCRIPTION
## Summary
- replace the footer icon badge on every public page with the Gliwicka 111 logotype image
- keep the Property Management caption under the logo and ensure Next.js Image is imported where required
- drop the unused Building2 icon import on the contact page

## Testing
- npm run dev (manual verification of footer layout)


------
https://chatgpt.com/codex/tasks/task_e_68d7ae67d9388329b12445741d718610