### PR TITLE
Inline footer logo image attributes

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -349,12 +349,7 @@ export default async function AboutPage() {
                   className="inline-flex items-center hover:opacity-80 transition-opacity"
                   aria-label="Gliwicka 111 — Property Management"
                 >
-                  <Image
-                    src="/gliwicka111w.svg"
-                    alt="Gliwicka 111 — Property Management"
-                    width={200}
-                    height={200}
-                  />
+                  <Image src="/gliwicka111w.svg" alt="Gliwicka 111 — Property Management" width={200} height={200} />
                 </Link>
               </div>
               <p className="text-slate-400 mb-6 max-w-md">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -561,12 +561,7 @@ export default function ContactPage() {
                   className="inline-flex items-center hover:opacity-80 transition-opacity"
                   aria-label="Gliwicka 111 — Property Management"
                 >
-                  <Image
-                    src="/gliwicka111w.svg"
-                    alt="Gliwicka 111 — Property Management"
-                    width={200}
-                    height={200}
-                  />
+                  <Image src="/gliwicka111w.svg" alt="Gliwicka 111 — Property Management" width={200} height={200} />
                 </Link>
               </div>
               <p className="text-slate-400 mb-6 max-w-md">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1905,12 +1905,7 @@ export default function HomePage() {
                   className="inline-flex items-center hover:opacity-80 transition-opacity"
                   aria-label="Gliwicka 111 — Property Management"
                 >
-                  <Image
-                    src="/gliwicka111w.svg"
-                    alt="Gliwicka 111 — Property Management"
-                    width={200}
-                    height={200}
-                  />
+                  <Image src="/gliwicka111w.svg" alt="Gliwicka 111 — Property Management" width={200} height={200} />
                 </Link>
               </div>
               <p className="text-slate-400 mb-6 max-w-md">

--- a/app/properties/page.tsx
+++ b/app/properties/page.tsx
@@ -382,12 +382,7 @@ export default function PropertiesPage() {
                     className="inline-flex items-center hover:opacity-80 transition-opacity"
                     aria-label="Gliwicka 111 — Property Management"
                   >
-                    <Image
-                      src="/gliwicka111w.svg"
-                      alt="Gliwicka 111 — Property Management"
-                      width={200}
-                      height={200}
-                    />
+                    <Image src="/gliwicka111w.svg" alt="Gliwicka 111 — Property Management" width={200} height={200} />
                   </Link>
                 </div>
                 <p className="text-slate-400 mb-6 max-w-md">


### PR DESCRIPTION
## Summary
- inline the footer logo Image components so they only define src, alt, width, and height attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da4e7c5610832986e7c10f7cdd8478